### PR TITLE
Authorizes PRINT_EXPR after expr. Make single mode compile work

### DIFF
--- a/pytest/test_deparse.py
+++ b/pytest/test_deparse.py
@@ -313,7 +313,7 @@ def test_single_mode():
         'i = {}',
         'i = []',
         'while i < 1 or stop:\n    i\n',
-        'while i < 1 or stop:\n    print(i)\n',
+        'while i < 1 or stop:\n    print%s\n' % ('(i)' if PYTHON3 else ' i'),
         'for i in range(10):\n    i\n',
         'for i in range(10):\n    for j in range(10):\n        i + j\n',
         'try:\n    i\nexcept Exception:\n    j\nelse:\n    k\n'

--- a/pytest/test_deparse.py
+++ b/pytest/test_deparse.py
@@ -1,5 +1,5 @@
 from uncompyle6.semantics.fragments import deparse_code as deparse
-from uncompyle6 import PYTHON_VERSION, PYTHON3
+from uncompyle6 import PYTHON_VERSION, PYTHON3, deparse_code
 
 def map_stmts(x, y):
     x = []
@@ -302,3 +302,23 @@ for i in range(2): ...
     parsed = get_parsed_for_fn(for_range_stmt)
     if not PYTHON3:
         check_expect(expect, parsed)
+
+
+def test_single_mode():
+    single_expressions = (
+        'i = 1',
+        'i and (j or k)',
+        'i += 1',
+        'i = j % 4',
+        'i = {}',
+        'i = []',
+        'while i < 1 or stop:\n    i\n',
+        'while i < 1 or stop:\n    print(i)\n',
+        'for i in range(10):\n    i\n',
+        'for i in range(10):\n    for j in range(10):\n        i + j\n',
+        'try:\n    i\nexcept Exception:\n    j\nelse:\n    k\n'
+    )
+
+    for expr in single_expressions:
+        code = compile(expr + '\n', '<string>', 'single')
+        assert deparse_code(PYTHON_VERSION, code).text == expr + '\n'

--- a/uncompyle6/parsers/parse2.py
+++ b/uncompyle6/parsers/parse2.py
@@ -285,6 +285,7 @@ class Python2Parser(PythonParser):
         stmt ::= classdef
         stmt ::= call_stmt
         call_stmt ::= expr POP_TOP
+        call_stmt ::= expr PRINT_EXPR
 
         stmt ::= return_stmt
         return_stmt ::= ret_expr RETURN_VALUE

--- a/uncompyle6/parsers/parse3.py
+++ b/uncompyle6/parsers/parse3.py
@@ -302,6 +302,7 @@ class Python3Parser(PythonParser):
         stmt ::= classdef
         stmt ::= call_stmt
         call_stmt ::= expr POP_TOP
+        call_stmt ::= expr PRINT_EXPR
 
         stmt ::= return_stmt
         return_stmt ::= ret_expr RETURN_VALUE


### PR DESCRIPTION
This makes single compile work:

```python
deparse_code(v, compile('int(1 + 1)', '<string>', 'single'))
```

Please review because I'm not really sure of what I did.