### PR TITLE
Fix for class decorators

### DIFF
--- a/uncompyle6/semantics/pysource.py
+++ b/uncompyle6/semantics/pysource.py
@@ -261,8 +261,8 @@ TABLE_DIRECT = {
     'funcdefdeco':  	( '\n\n%c', 0),
     'mkfuncdeco':  	( '%|@%c\n%c', 0, 1),
     'mkfuncdeco0':  	( '%|def %c\n', 0),
-    'classdefdeco':  	( '%c', 0),
-    'classdefdeco1':  	( '\n\n%|@%c%c', 0, 1),
+    'classdefdeco':  	( '\n\n%c', 0),
+    'classdefdeco1':  	( '%|@%c\n%c', 0, 1),
     'kwarg':    	( '%[0]{pattr}=%c', 1),
     'kwargs':    	( '%D', (0, maxint, ', ') ),
     'importlist2':	( '%C', (0, maxint, ', ') ),
@@ -1146,7 +1146,7 @@ class SourceWalker(GenericASTTraversal, object):
                 subclass = buildclass[1][0].attr
             subclass_info = node[0]
         else:
-            buildclass = node[0]
+            buildclass = node if (node == 'classdefdeco2') else node[0]
             build_list = buildclass[1][0]
             if hasattr(buildclass[-3][0], 'attr'):
                 subclass = buildclass[-3][0].attr
@@ -1157,7 +1157,11 @@ class SourceWalker(GenericASTTraversal, object):
             else:
                 raise 'Internal Error n_classdef: cannot find class name'
 
-        self.write('\n\n')
+        if (node == 'classdefdeco2'):
+            self.write('\n')
+        else:
+            self.write('\n\n')
+
         self.currentclass = str(currentclass)
         self.write(self.indent, 'class ', self.currentclass)
 


### PR DESCRIPTION
This PR fixes the decompilation of class decorators. It crashes with current master version because the handler for `classdefdeco2` is the same as for `classdef` while the structure of both nodes is slightly different.

The changes simply imply checking the node type and choose the appropriate child to consider as the `buildclass`. Also, there are some cosmetic changes so that the decorations are glued to the class definition and glued together.

You can test the changes by compiling [this Python file](https://gist.github.com/Tey/0d00c9313ab6770ff211328552d411e1#file-classdec_test-py).

**Similar changes are probably needed for Python 3 files** ([line 1142](https://github.com/rocky/python-uncompyle6/pull/15/files#diff-2f08c9a8823cc79320bcf701cf255fc9R1142)), but I don't have such a version installed so I can't test it.