### PR TITLE
Fixed bug in pysource / fragments where the use of deparse_code from …

### DIFF
--- a/uncompyle6/semantics/fragments.py
+++ b/uncompyle6/semantics/fragments.py
@@ -36,7 +36,7 @@ from uncompyle6 import parser
 from uncompyle6.scanner import Token, Code, get_scanner
 
 from uncompyle6.semantics.pysource import AST, INDENT_PER_LEVEL, NONE, PRECEDENCE, \
-     ParserError, TABLE_DIRECT, escape, find_all_globals, find_globals, find_none, minint
+     ParserError, TABLE_DIRECT, escape, find_all_globals, find_globals, find_none, minint, MAP
 
 if PYTHON3:
     from itertools import zip_longest
@@ -67,7 +67,12 @@ TABLE_DIRECT_FRAGMENT = {
         '%|for %c%x in %c:\n%+%c%-%|else:\n%+%c%-\n\n', 3, (3, (2,)), 1, 4, -2),
     }
 
+
+MAP_DIRECT_FRAGMENT = dict(TABLE_DIRECT, **TABLE_DIRECT_FRAGMENT),
+
+
 class FragmentsWalker(pysource.SourceWalker, object):
+
     stacked_params = ('f', 'indent', 'isLambda', '_globals')
 
     def __init__(self, version, scanner, showast=False,
@@ -94,9 +99,6 @@ class FragmentsWalker(pysource.SourceWalker, object):
 
         self.offsets = {}
         self.last_finish = -1
-
-        # Customize with our more-pervisive rules
-        TABLE_DIRECT.update(TABLE_DIRECT_FRAGMENT)
 
     f = property(lambda s: s.params['f'],
                  lambda s, x: s.params.__setitem__('f', x),
@@ -1441,6 +1443,10 @@ class FragmentsWalker(pysource.SourceWalker, object):
         self.gen_source(ast, code.co_name, code._customize, isLambda=isLambda,
                           returnNone=rn)
         code._tokens = None; code._customize = None # save memory
+
+    @classmethod
+    def _get_mapping(cls, node):
+        return MAP.get(node, MAP_DIRECT_FRAGMENT)
 
     pass
 

--- a/uncompyle6/semantics/pysource.py
+++ b/uncompyle6/semantics/pysource.py
@@ -1526,7 +1526,7 @@ class SourceWalker(GenericASTTraversal, object):
         self.write(fmt[i:])
 
     def default(self, node):
-        mapping = MAP.get(node, MAP_DIRECT)
+        mapping = self._get_mapping(node)
         table = mapping[0]
         key = node
 
@@ -1860,6 +1860,11 @@ class SourceWalker(GenericASTTraversal, object):
             self.println(repr(ast))
 
         return ast
+
+    @classmethod
+    def _get_mapping(cls, node):
+        return MAP.get(node, MAP_DIRECT)
+
 
 def deparse_code(version, co, out=sys.stdout, showasm=False, showast=False,
                  showgrammar=False, code_objects={}, compile_mode='exec'):


### PR DESCRIPTION
…fragments could break subsequent calls to deparse_code from pysource due to amending to the global TABLE_DIRECT. (This is only really highlighted in the still work in progress pytest data driven test branch, where subsequent calls from the same process would cause this to happen)