### PR TITLE
merge fstring changes from moagstar

### DIFF
--- a/pytest/test_fstring.py
+++ b/pytest/test_fstring.py
@@ -87,19 +87,23 @@ def fstrings(draw):
 
     :return: A valid f-string.
     """
+    character_strategy = st.characters(
+        blacklist_characters='\r\n\'\\s{}',
+        min_codepoint=1,
+        max_codepoint=1000,
+    )
     is_raw = draw(st.booleans())
     integer_strategy = st.integers(min_value=0, max_value=3)
     expression_count = draw(integer_strategy)
     content = []
     for _ in range(expression_count):
         expression = draw(expressions())
-        # not yet : conversion not supported
-        conversion = ''#draw(st.sampled_from(('', '!s', '!r', '!a',)))
+        conversion = draw(st.sampled_from(('', '!s', '!r', '!a',)))
         has_specifier = draw(st.booleans())
         specifier = ':' + draw(format_specifiers()) if has_specifier else ''
         content.append('{{{}{}}}'.format(expression, conversion, specifier))
+        content.append(draw(st.text(character_strategy)))
     content = ''.join(content)
-
     return "f{}'{}'".format('r' if is_raw else '', content)
 
 
@@ -114,23 +118,27 @@ def test_format_specifiers(format_specifier):
             raise
 
 
+def run_test(text):
+    expr = text + '\n'
+    code = compile(expr, '<string>', 'single')
+    deparsed = deparse_code(PYTHON_VERSION, code, compile_mode='single')
+    recompiled = compile(deparsed.text, '<string>', 'single')
+    if recompiled != code:
+        assert 'dis(' + deparsed.text.strip('\n') + ')' == 'dis(' + expr.strip('\n') + ')'
+
+
 @pytest.mark.skipif(PYTHON_VERSION < 3.6, reason='need at least python 3.6')
 @hypothesis.given(fstrings())
 def test_uncompyle_fstring(fstring):
     """Verify uncompyling fstring bytecode"""
+    run_test(fstring)
 
-    # ignore fstring with no expressions an fsring with
-    # no expressions just gets compiled to a normal string.
-    hypothesis.assume('{' in fstring)
 
-    # BUG : At the moment a single expression is not supported
-    # for example f'{abc}'.
-    hypothesis.assume(fstring.count('{') > 1)
-
-    expr = fstring + '\n'
-    code = compile(expr, '<string>', 'single')
-    deparsed = deparse_code(PYTHON_VERSION, code, compile_mode='single')
-    recompiled = compile(deparsed.text, '<string>', 'single')
-
-    if recompiled != code:
-        assert deparsed.text == expr
+@pytest.mark.skipif(PYTHON_VERSION < 3.6, reason='need at least python 3.6')
+@pytest.mark.parametrize('fstring', [
+    #"f'{abc}{abc!s}'",
+    "f'{abc!s}'",
+])
+def test_uncompyle_direct(fstring):
+    """useful for debugging"""
+    run_test(fstring)

--- a/uncompyle6/parsers/parse3.py
+++ b/uncompyle6/parsers/parse3.py
@@ -462,13 +462,9 @@ class Python3Parser(PythonParser):
             elif opname == 'FORMAT_VALUE':
                 # Python 3.6+
                 self.addRule("""
-                formatted_value ::= expr FORMAT_VALUE
-                formatted_value ::= expr FORMAT_VALUE
-                str ::= LOAD_CONST
-                formatted_value_or_str ::= formatted_value
-                formatted_value_or_str ::= str
+                    expr ::= fstring_expr
+                    fstring_expr ::= expr FORMAT_VALUE
                 """, nop_func)
-                saw_format_value = True
 
             elif opname in ('CALL_FUNCTION', 'CALL_FUNCTION_VAR',
                             'CALL_FUNCTION_VAR_KW', 'CALL_FUNCTION_KW'):
@@ -493,7 +489,6 @@ class Python3Parser(PythonParser):
                     rule = ('load_closure ::= %s%s' % (('LOAD_CLOSURE ' * v), opname))
                     self.add_unique_rule(rule, opname, token.attr, customize)
                 if opname_base == 'BUILD_LIST' and saw_format_value:
-                    saw_format_value = False
                     format_or_str_n = "formatted_value_or_str_%s" % v
                     self.addRule("""
                     expr ::= joined_str

--- a/uncompyle6/semantics/pysource.py
+++ b/uncompyle6/semantics/pysource.py
@@ -1776,7 +1776,7 @@ class SourceWalker(GenericASTTraversal, object):
             node[-2][0].type = 'unpack_w_parens'
         self.default(node)
 
-    FSTRING_CONVERSION_MAP = {i+1: '!'+x for i, x in enumerate('sra')}
+    FSTRING_CONVERSION_MAP = {1: '!s', 2: '!r', 3: '!a'}
 
     def n_fstring_expr(self, node):
         node.conversion = self.FSTRING_CONVERSION_MAP.get(node.data[1].attr, '')

--- a/uncompyle6/semantics/pysource.py
+++ b/uncompyle6/semantics/pysource.py
@@ -624,9 +624,7 @@ class SourceWalker(GenericASTTraversal, object):
                 # Python 3.6+ Additions
                 #######################
                 TABLE_DIRECT.update({
-                    'formatted_value': ( '{%c%c}', 0, 1),
-                    'FORMAT_VALUE': ( '%{pattr}', ),
-                    'joined_str':  ( "f'%c'", 2),
+                    'fstring_expr': ( "f'{%c%{conversion}}'", 0),
                 })
         return
 
@@ -1776,6 +1774,12 @@ class SourceWalker(GenericASTTraversal, object):
     def n_except_cond2(self, node):
         if node[-2][0] == 'unpack':
             node[-2][0].type = 'unpack_w_parens'
+        self.default(node)
+
+    FSTRING_CONVERSION_MAP = {i+1: '!'+x for i, x in enumerate('sra')}
+
+    def n_fstring_expr(self, node):
+        node.conversion = self.FSTRING_CONVERSION_MAP.get(node.data[1].attr, '')
         self.default(node)
 
     def engine(self, entry, startnode):


### PR DESCRIPTION
Changed fstring decompilation so that the call to join is left intact rather than trying to reconstruct the original fstring from the various expression parts. This allows f strings with 0, 1 and multiple expressions to be decompiled. It also simplifies decompilation of conversion specifiers !s !r !