### PR TITLE
Revert "fix bug : not generate all files when use "-ro""

### DIFF
--- a/uncompyle6/main.py
+++ b/uncompyle6/main.py
@@ -143,7 +143,6 @@ def main(in_base, out_base, files, codes, outfile=None,
         # Try to uncompile the input file
         try:
             decompile_file(infile, outstream, showasm, showast, showgrammar)
-            outfile = None        
             tot_files += 1
         except (ValueError, SyntaxError, ParserError, pysource.SourceWalkerError) as e:
             sys.stdout.write("\n")


### PR DESCRIPTION
Reverts rocky/python-uncompyle6#78

This create a _lot_ of unnecessary output when I run "make check". 