### PR TITLE
Property based test function call

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@
 /unpyc
 __pycache__
 build
+/.venv*

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@
 __pycache__
 build
 /.venv*
+/.idea

--- a/pytest/test_function_call.py
+++ b/pytest/test_function_call.py
@@ -46,14 +46,17 @@ def function_calls(draw):
     return function_call
 
 
+@pytest.mark.xfail()
 def test_CALL_FUNCTION():
     validate_uncompyle("fn(w,m,f)")
 
 
+@pytest.mark.xfail()
 def test_BUILD_CONST_KEY_MAP_BUILD_MAP_UNPACK_WITH_CALL_BUILD_TUPLE_CALL_FUNCTION_EX():
     validate_uncompyle("fn(w=0,m=0,**v)")
 
 
+@pytest.mark.xfail()
 def test_BUILD_MAP_BUILD_MAP_UNPACK_WITH_CALL_BUILD_TUPLE_CALL_FUNCTION_EX():
     validate_uncompyle("fn(a=0,**g)")
 

--- a/pytest/test_function_call.py
+++ b/pytest/test_function_call.py
@@ -1,8 +1,8 @@
 # std
 import string
 # 3rd party
-from hypothesis import strategies as st
-from hypothesis import given, assume
+from hypothesis import given, assume, example, strategies as st
+import pytest
 # uncompyle
 from validate import validate_uncompyle
 
@@ -22,10 +22,13 @@ def function_calls(draw):
 
     :return: The function call text.
     """
-    positional_args = draw(st.lists(alphanum, min_size=0, max_size=3))
-    named_args = [x + '=0' for x in draw(st.lists(alpha, min_size=0, max_size=3))]
-    star_args = ['*' + x for x in draw(st.lists(alpha, min_size=0, max_size=1))]
-    double_star_args = ['**' + x for x in draw(st.lists(alpha, min_size=0, max_size=1))]
+    list1 = st.lists(alpha, min_size=0, max_size=1)
+    list3 = st.lists(alpha, min_size=0, max_size=3)
+
+    positional_args = draw(list3)
+    named_args = [x + '=0' for x in draw(list3)]
+    star_args = ['*' + x for x in draw(list1)]
+    double_star_args = ['**' + x for x in draw(list1)]
 
     arguments = positional_args + named_args + star_args + double_star_args
     draw(st.randoms()).shuffle(arguments)
@@ -33,8 +36,8 @@ def function_calls(draw):
 
     function_call = 'fn({arguments})'.format(arguments=arguments)
     try:
-        # TODO: Figure out the exact rules for ordering of positional named,
-        # star args and double star args and in which versions the various
+        # TODO: Figure out the exact rules for ordering of positional, named,
+        # star args, double star args and in which versions the various
         # types of arguments are supported so we don't need to check that the
         # expression compiles like this.
         compile(function_call, '<string>', 'single')
@@ -43,6 +46,42 @@ def function_calls(draw):
     return function_call
 
 
+@pytest.mark.xfail()
 @given(function_calls())
+@example('fn(i,d)')                       # CALL_FUNCTION
+@example('fn(*q)')                        # CALL_FUNCTION_EX
+@example('fn(**n)')                       # BUILD_TUPLE, CALL_FUNCTION_EX
+@example('fn(r=0)')                       # CALL_FUNCTION_KW
+@example('fn(q=0,**f)')                   # BUILD_MAP, BUILD_MAP_UNPACK_WITH_CALL, BUILD_TUPLE, CALL_FUNCTION_EX
+@example('fn(h,*b)')                      # BUILD_TUPLE, BUILD_TUPLE_UNPACK_WITH_CALL, CALL_FUNCTION_EX
+@example('fn(*a,a=0)')                    # BUILD_MAP, CALL_FUNCTION_EX
+@example('fn(**m,i=0,a=0,b=0)')           # BUILD_CONST_KEY_MAP, BUILD_MAP_UNPACK_WITH_CALL, BUILD_TUPLE, CALL_FUNCTION_EX
+@example('fn(l=0,v=0,*e,f=0)')            # BUILD_CONST_KEY_MAP, CALL_FUNCTION_EX
+@example('fn(*c,a=0,**t)')                # BUILD_MAP, BUILD_MAP_UNPACK_WITH_CALL, CALL_FUNCTION_EX
+@example('fn(p=0,*a,n=0,a=0,**a)')        # BUILD_CONST_KEY_MAP, BUILD_MAP_UNPACK_WITH_CALL, CALL_FUNCTION_EX
+@example('fn(l=0,**d,o=0,f=0)')           # BUILD_CONST_KEY_MAP, BUILD_MAP, BUILD_MAP_UNPACK_WITH_CALL, BUILD_TUPLE, CALL_FUNCTION_EX
+@example('fn(t=0,s=0,*c,**f,g=0)')        # BUILD_CONST_KEY_MAP, BUILD_MAP, BUILD_MAP_UNPACK_WITH_CALL, CALL_FUNCTION_EX
+@example('fn(b,o,b=0,*a)')                # BUILD_MAP, BUILD_TUPLE, BUILD_TUPLE_UNPACK_WITH_CALL, CALL_FUNCTION_EX
 def test_function_call(function_call):
     validate_uncompyle(function_call)
+
+
+examples = []
+
+
+@pytest.mark.skip()
+@given(function_calls())
+def test_generate_hypothesis(function_call):
+    examples = set()
+    examples.add(function_call)
+
+
+@pytest.mark.skip()
+def test_generate_examples():
+    import dis
+    example_opcodes = {}
+    for example in examples:
+        opcodes = tuple(sorted(set(instruction.opname for instruction in dis.Bytecode(example))))
+        example_opcodes[opcodes] = example
+    for k, v in example_opcodes.items():
+        print("@example('" + v + "')   # ", ', '.join(k))

--- a/pytest/test_function_call.py
+++ b/pytest/test_function_call.py
@@ -1,0 +1,48 @@
+# std
+import string
+# 3rd party
+from hypothesis import strategies as st
+from hypothesis import given, assume
+# uncompyle
+from validate import validate_uncompyle
+
+
+alpha = st.sampled_from(string.ascii_lowercase)
+numbers = st.sampled_from(string.digits)
+alphanum = st.sampled_from(string.ascii_lowercase + string.digits)
+expressions = st.sampled_from([x for x in string.ascii_lowercase + string.digits] + ['x+1'])
+
+
+@st.composite
+def function_calls(draw):
+    """
+    Strategy factory for generating function calls.
+
+    :param draw: Callable which draws examples from other strategies.
+
+    :return: The function call text.
+    """
+    positional_args = draw(st.lists(alphanum, min_size=0, max_size=3))
+    named_args = [x + '=0' for x in draw(st.lists(alpha, min_size=0, max_size=3))]
+    star_args = ['*' + x for x in draw(st.lists(alpha, min_size=0, max_size=1))]
+    double_star_args = ['**' + x for x in draw(st.lists(alpha, min_size=0, max_size=1))]
+
+    arguments = positional_args + named_args + star_args + double_star_args
+    draw(st.randoms()).shuffle(arguments)
+    arguments = ','.join(arguments)
+
+    function_call = 'fn({arguments})'.format(arguments=arguments)
+    try:
+        # TODO: Figure out the exact rules for ordering of positional named,
+        # star args and double star args and in which versions the various
+        # types of arguments are supported so we don't need to check that the
+        # expression compiles like this.
+        compile(function_call, '<string>', 'single')
+    except:
+        assume(False)
+    return function_call
+
+
+@given(function_calls())
+def test_function_call(function_call):
+    validate_uncompyle(function_call)

--- a/pytest/test_function_call.py
+++ b/pytest/test_function_call.py
@@ -1,7 +1,7 @@
 # std
 import string
 # 3rd party
-from hypothesis import given, assume, settings, example, strategies as st
+from hypothesis import given, assume, strategies as st
 import pytest
 # uncompyle
 from validate import validate_uncompyle

--- a/pytest/validate.py
+++ b/pytest/validate.py
@@ -2,18 +2,23 @@
 from __future__ import print_function
 # std
 import os
-import dis
 import difflib
 import subprocess
 import tempfile
+import functools
 # compatability
 import six
 # uncompyle6 / xdis
-from uncompyle6 import PYTHON_VERSION, deparse_code
+from uncompyle6 import PYTHON_VERSION, IS_PYPY, deparse_code
+# TODO : I think we can get xdis to support the dis api (python 3 version) by doing something like this there
+from xdis.bytecode import Bytecode
+from xdis.main import get_opcode
+opc = get_opcode(PYTHON_VERSION, IS_PYPY)
+Bytecode = functools.partial(Bytecode, opc=opc)
 
 
 def _dis_to_text(co):
-    return dis.Bytecode(co).dis()
+    return Bytecode(co).dis()
 
 
 def print_diff(original, uncompyled):
@@ -99,9 +104,8 @@ def are_code_objects_equal(co1, co2):
 
     :return: True if the two code objects are approximately equal, otherwise False.
     """
-    # TODO : Use xdis for python2 compatability
-    instructions1 = dis.Bytecode(co1)
-    instructions2 = dis.Bytecode(co2)
+    instructions1 = Bytecode(co1)
+    instructions2 = Bytecode(co2)
     for opcode1, opcode2 in zip(instructions1, instructions2):
         if not are_instructions_equal(opcode1, opcode2):
             return False


### PR DESCRIPTION
I've added some basic tests which should hopefully cover the majority of the new python 3.6 bytecodes and semantic changes for function calls. The majority of these tests are currently failing so I have marked these tests as expected failures. I wanted to merge these tests separately since I'd like to try and tackle the various issues in separate branches as I get time to do so, all of these will depend on these tests.

There is also a property based test which should test the various combinations more thoroughly, this test is skipped until the others are all passing.