### PR TITLE
Keep global statements in fixed order

### DIFF
--- a/uncompyle6/semantics/aligner.py
+++ b/uncompyle6/semantics/aligner.py
@@ -128,8 +128,8 @@ def align_deparse_code(version, co, out=sys.stderr, showasm=False, showast=False
     # What we've been waiting for: Generate Python source from the parse tree!
     deparsed.gen_source(deparsed.ast, co.co_name, customize)
 
-    for g in deparsed.mod_globs:
-        deparsed.write('# global %s ## Warning: Unused global' % g)
+    for g in sorted(deparsed.mod_globs):
+        deparsed.write('# global %s ## Warning: Unused global\n' % g)
 
     if deparsed.ERROR:
         raise SourceWalkerError("Deparsing stopped due to parse error")

--- a/uncompyle6/semantics/fragments.py
+++ b/uncompyle6/semantics/fragments.py
@@ -1768,8 +1768,8 @@ def deparse_code(version, co, out=StringIO(), showasm=False, showast=False,
     deparsed.set_pos_info(deparsed.ast, 0, len(deparsed.text))
     deparsed.fixup_parents(deparsed.ast, None)
 
-    for g in deparsed.mod_globs:
-        deparsed.write('# global %s ## Warning: Unused global' % g)
+    for g in sorted(deparsed.mod_globs):
+        deparsed.write('# global %s ## Warning: Unused global\n' % g)
 
     if deparsed.ast_errors:
         deparsed.write("# NOTE: have decompilation errors.\n")

--- a/uncompyle6/semantics/make_function.py
+++ b/uncompyle6/semantics/make_function.py
@@ -256,7 +256,7 @@ def make_function3_annotate(self, node, is_lambda, nested=1,
     assert ast == 'stmts'
 
     all_globals = find_all_globals(ast, set())
-    for g in ((all_globals & self.mod_globs) | find_globals(ast, set())):
+    for g in sorted((all_globals & self.mod_globs) | find_globals(ast, set())):
         self.println(self.indent, 'global ', g)
     self.mod_globs -= all_globals
     has_none = 'None' in code.co_names
@@ -409,7 +409,7 @@ def make_function2(self, node, is_lambda, nested=1, codeNode=None):
         assert ast == 'stmts'
 
     all_globals = find_all_globals(ast, set())
-    for g in ((all_globals & self.mod_globs) | find_globals(ast, set())):
+    for g in sorted((all_globals & self.mod_globs) | find_globals(ast, set())):
         self.println(self.indent, 'global ', g)
     self.mod_globs -= all_globals
     has_none = 'None' in code.co_names
@@ -655,7 +655,7 @@ def make_function3(self, node, is_lambda, nested=1, codeNode=None):
     assert ast == 'stmts'
 
     all_globals = find_all_globals(ast, set())
-    for g in ((all_globals & self.mod_globs) | find_globals(ast, set())):
+    for g in sorted((all_globals & self.mod_globs) | find_globals(ast, set())):
         self.println(self.indent, 'global ', g)
     self.mod_globs -= all_globals
     has_none = 'None' in code.co_names

--- a/uncompyle6/semantics/pysource.py
+++ b/uncompyle6/semantics/pysource.py
@@ -2517,7 +2517,7 @@ class SourceWalker(GenericASTTraversal, object):
 
         # Add "global" declaration statements at the top
         # of the function
-        for g in find_globals(ast, set()):
+        for g in sorted(find_globals(ast, set())):
             self.println(indent, 'global ', g)
 
         old_name = self.name
@@ -2674,8 +2674,8 @@ def deparse_code(version, co, out=sys.stdout, showasm=None, showast=False,
     # What we've been waiting for: Generate source from Syntax Tree!
     deparsed.gen_source(deparsed.ast, co.co_name, customize)
 
-    for g in deparsed.mod_globs:
-        deparsed.write('# global %s ## Warning: Unused global' % g)
+    for g in sorted(deparsed.mod_globs):
+        deparsed.write('# global %s ## Warning: Unused global\n' % g)
 
     if deparsed.ast_errors:
         deparsed.write("# NOTE: have internal decompilation grammar errors.\n")


### PR DESCRIPTION
The `global` statements stored in a set() when generating code. The order of multiple `global` is not fixed.
When using a decompile bot to detect code changes, this will cause false positive.
This PR is to keep multiple `global` statements in fixed order.