### PR TITLE
Extended args handling to address 3.6+ problems

### DIFF
--- a/pytest/test_fjt.py
+++ b/pytest/test_fjt.py
@@ -28,7 +28,7 @@ def test_if_in_for():
     if 2.7 <= PYTHON_VERSION <= 3.0 and not IS_PYPY:
         n = scan.setup_code(code)
         bytecode = Bytecode(code, scan.opc)
-        scan.build_lines_data(code, n)
+        scan.lines = scan.build_lines_data(code, n)
         scan.insts = list(bytecode)
         scan.offset2inst_index = {}
         for i, inst in enumerate(scan.insts):
@@ -50,7 +50,7 @@ def test_if_in_for():
         code = bug_loop.__code__
         n = scan.setup_code(code)
         bytecode = Bytecode(code, scan.opc)
-        scan.build_lines_data(code, n)
+        scan.lines = scan.build_lines_data(code, n)
         scan.insts = list(bytecode)
         scan.build_prev_op(n)
         scan.offset2inst_index = {}
@@ -71,7 +71,7 @@ def test_if_in_for():
     elif 3.2 < PYTHON_VERSION <= 3.4:
         bytecode = Bytecode(code, scan.opc)
         scan.code = array('B', code.co_code)
-        scan.build_lines_data(code)
+        scan.lines = scan.build_lines_data(code)
         scan.build_prev_op()
         scan.insts = list(bytecode)
         scan.offset2inst_index = {}

--- a/pytest/test_fjt.py
+++ b/pytest/test_fjt.py
@@ -28,7 +28,7 @@ def test_if_in_for():
     if 2.7 <= PYTHON_VERSION <= 3.0 and not IS_PYPY:
         n = scan.setup_code(code)
         bytecode = Bytecode(code, scan.opc)
-        scan.lines = scan.build_lines_data(code, n)
+        scan.build_lines_data(code, n)
         scan.insts = list(bytecode)
         scan.offset2inst_index = {}
         for i, inst in enumerate(scan.insts):
@@ -50,7 +50,7 @@ def test_if_in_for():
         code = bug_loop.__code__
         n = scan.setup_code(code)
         bytecode = Bytecode(code, scan.opc)
-        scan.lines = scan.build_lines_data(code, n)
+        scan.build_lines_data(code, n)
         scan.insts = list(bytecode)
         scan.build_prev_op(n)
         scan.offset2inst_index = {}

--- a/uncompyle6/scanners/scanner3.py
+++ b/uncompyle6/scanners/scanner3.py
@@ -402,7 +402,6 @@ class Scanner3(Scanner):
                 # as CONTINUE, but that's okay since we add a grammar
                 # rule for that.
                 pattr = argval
-                # FIXME: 0 isn't always correct
                 target = self.get_target(inst.offset)
                 if target <= inst.offset:
                     next_opname = self.insts[i+1].opname

--- a/uncompyle6/scanners/scanner3.py
+++ b/uncompyle6/scanners/scanner3.py
@@ -275,6 +275,10 @@ class Scanner3(Scanner):
                 for jump_offset in sorted(jump_targets[inst.offset], reverse=True):
                     come_from_name = 'COME_FROM'
                     opname = self.opname_for_offset(jump_offset)
+                    if opname == 'EXTENDED_ARG':
+                        j = xdis.next_offset(op, self.opc, jump_offset)
+                        opname = self.opname_for_offset(j)
+
                     if opname.startswith('SETUP_'):
                         come_from_type = opname[len('SETUP_'):]
                         come_from_name = 'COME_FROM_%s' % come_from_type
@@ -545,7 +549,12 @@ class Scanner3(Scanner):
             if inst.has_arg:
                 label = self.fixed_jumps.get(offset)
                 oparg = inst.arg
-                next_offset = xdis.next_offset(op, self.opc, offset)
+                if (self.version >= 3.6 and
+                    self.code[offset] == self.opc.EXTENDED_ARG):
+                    j = xdis.next_offset(op, self.opc, offset)
+                    next_offset = xdis.next_offset(op, self.opc, j)
+                else:
+                    next_offset = xdis.next_offset(op, self.opc, offset)
 
                 if label is None:
                     if op in op3.hasjrel and op != self.opc.FOR_ITER:


### PR DESCRIPTION
Python 3.6 and later in switching to word sizes reduces the potential sizes of operands.

This in turn means that there are many more EXTENDED_ARG instructions allow be able to handle operands requiring more than a byte.  

In trying to remove these and working with instructions, there will be gaps in offsets where the EXTENDED_ARG instructions have been removed. 

Right now our processing still is a mixture of the opcode array and the instruction array. 

This code is messy, but right now it's the best we can do. 