### PR TITLE
Better assert and AssertionError determination on 2.7

### DIFF
--- a/uncompyle6/parsers/parse2.py
+++ b/uncompyle6/parsers/parse2.py
@@ -533,14 +533,11 @@ class Python2Parser(PythonParser):
         # Dead code testing...
         # if lhs == 'while1elsestmt':
         #     from trepan.api import debug; debug()
-
         if lhs in ('aug_assign1', 'aug_assign2') and ast[0] and ast[0][0] in ('and', 'or'):
             return True
         elif lhs in ('raise_stmt1',):
-            # We will assme 'LOAD_ASSERT' will be handled by an assert grammar rule
-            return (tokens[first] == 'LOAD_ASSERT' and
-                    (last >= len(tokens) or tokens[last] not in
-                     ('COME_FROM', 'JUMP_BACK','JUMP_FORWARD')))
+            # We will assume 'LOAD_ASSERT' will be handled by an assert grammar rule
+            return (tokens[first] == 'LOAD_ASSERT' and (last >= len(tokens)))
         elif rule == ('or', ('expr', 'jmp_true', 'expr', '\\e_come_from_opt')):
             expr2 = ast[2]
             return expr2 == 'expr' and expr2[0] == 'LOAD_ASSERT'

--- a/uncompyle6/parsers/parse27.py
+++ b/uncompyle6/parsers/parse27.py
@@ -3,6 +3,7 @@
 #  Copyright (c) 2000-2002 by hartmut Goebel <hartmut@goebel.noris.de>
 
 from spark_parser import DEFAULT_DEBUG as PARSER_DEFAULT_DEBUG
+from xdis import next_offset
 from uncompyle6.parser import PythonParserSingle
 from uncompyle6.parsers.parse2 import Python2Parser
 
@@ -225,7 +226,9 @@ class Python27Parser(Python2Parser):
         elif rule[0] in ('assert', 'assert2'):
             jump_inst = ast[1][0]
             jump_target = jump_inst.attr
-            return not (last >= len(tokens) or jump_target == tokens[last].offset)
+            return not (last >= len(tokens)
+                        or jump_target == tokens[last].offset
+                        or jump_target == next_offset(ast[-1].op, ast[-1].opc, ast[-1].offset))
         elif rule == ('list_if_not', ('expr', 'jmp_true', 'list_iter')):
             jump_inst = ast[1][0]
             jump_offset = jump_inst.attr

--- a/uncompyle6/parsers/parse27.py
+++ b/uncompyle6/parsers/parse27.py
@@ -200,6 +200,8 @@ class Python27Parser(Python2Parser):
         self.check_reduce['and'] = 'AST'
         # self.check_reduce['or'] = 'AST'
         self.check_reduce['raise_stmt1'] = 'AST'
+        self.check_reduce['assert'] = 'AST'
+        self.check_reduce['assert2'] = 'AST'
         self.check_reduce['list_if_not'] = 'AST'
         self.check_reduce['list_if'] = 'AST'
         self.check_reduce['conditional_true'] = 'AST'
@@ -220,6 +222,10 @@ class Python27Parser(Python2Parser):
                         tokens[last].pattr == jmp_false.pattr)
         elif rule[0] == ('raise_stmt1'):
             return ast[0] == 'expr' and ast[0][0] == 'or'
+        elif rule[0] in ('assert', 'assert2'):
+            jump_inst = ast[1][0]
+            jump_target = jump_inst.attr
+            return not (last >= len(tokens) or jump_target == tokens[last].offset)
         elif rule == ('list_if_not', ('expr', 'jmp_true', 'list_iter')):
             jump_inst = ast[1][0]
             jump_offset = jump_inst.attr


### PR DESCRIPTION
uncompyle6 3.2.5 on Python 3
python bytecode: 2.7

When I decompile https://github.com/Simplistix/testfixtures/blob/master/testfixtures/shouldraise.py,
the uncompyle6 failed with:

> Parse error at or near `JUMP_ABSOLUTE' instruction at offset 94

I simplified the code. Here is the code piece which can reproduce the error:
[case1]
```python
def func(a, b):
    if a:
        if not b:
            raise AssertionError("haha")
```

The disassembly:

```
   2       0  LOAD_FAST             0  'a'
           3  POP_JUMP_IF_FALSE    30  'to 30'

   3       6  LOAD_FAST             1  'b'
           9  POP_JUMP_IF_TRUE     30  'to 30'

   4      12  LOAD_ASSERT           0  'AssertionError'
          15  LOAD_CONST            1  'haha'
          18  CALL_FUNCTION_1       1  None
          21  RAISE_VARARGS_1       1  None
          24  JUMP_ABSOLUTE        30  'to 30'
          27  JUMP_FORWARD          0  'to 30'
        30_0  COME_FROM            27  '27'
```

According to https://github.com/rocky/python-uncompyle6/blob/master/uncompyle6/parsers/parse2.py#L539, the current logic is:

If there is a `LOAD_ASSERT` followed by a `COME_FROM` or `JUMP_BACK` or `JUMP_FORWARD`, it's a `raise AssertionError` statement; otherwise assume it will be handled by `assert` grammar rule.

In this case, the `LOAD_ASSERT` is followed by a `JUMP_ABSOLUTE`, which caused the problem. If I just add JUMP_ABSOLUTE to the check list, it seems that it can fix this case.

Then I found there is another case which can cause uncompyle6 failed: 
[case2]
```python
def func(a, b):
    if not a:
        raise AssertionError
        useless()
```
Although the `useless()` is useless, but it still can produce valid bytecodes. In this case, the `LOAD_ASSERT` is followed by a `LOAD_GLOBAL`. But obviously, we can not add `LOAD_GLOBAL` to the list.
For example:
[case3]
```python
def func(a, b):
    assert a
    useless()
```
The disassembly of case3 is very similar to case2. The difference is the target of `POP_JUMP_IF_TRUE`.
In case2, the `POP_JUMP_IF_TRUE` will jump to `COME_FROM` after useless part. In case3, the `POP_JUMP_IF_TRUE` will jump to useless part. 

My idea is, we should not use the instruction after `LOAD_ASSERT` to determine this is a `raise AssertionError` or `assert` statement. It's better to use the target of `POP_JUMP_IF_TRUE`: 
When checking `assert` grammar rule, if `POP_JUMP_IF_TRUE` jumps to the next instruction of `RAISE_VARARGS_1`,  it's an `assert` statement; otherwise, it will be handled by other grammar rule and be treated as a simple `raise` statement.

I tested with several cases, it seems works fine. If you think my idea is correct, I'll fix for other python versions and add some test case for it.