### PR TITLE
Travis CI: Add Python 3.7 to the testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,16 @@
 language: python
 
-sudo: false
-
 python:
   - '3.5'
   - '2.7'
   - '2.6'
   - '3.4'
   - '3.6'
+
+matrix:
+  include:
+    - python: '3.7'
+      dist: xenial  # required for Python >= 3.7 (travis-ci/travis-ci#9069)
 
 install:
 - pip install -e .


### PR DESCRIPTION
Also, [Travis are now recommending removing the __sudo__ tag](https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration).

Result __f-string__ failure: https://travis-ci.org/rocky/python-uncompyle6/jobs/477484760#L544