### PR TITLE
implements n_call_ex_kw as discussed in #227

### DIFF
--- a/uncompyle6/semantics/customize36.py
+++ b/uncompyle6/semantics/customize36.py
@@ -121,6 +121,32 @@ def customize_for_version36(self, version):
         return
     self.n_build_map_unpack_with_call = build_unpack_map_with_call
 
+    def call_ex_kw(node):
+        """Handle CALL_FUNCTION_EX 1 (have KW) but with
+        BUILD_MAP_UNPACK_WITH_CALL"""
+
+        expr = node[1]
+        assert expr == 'expr'
+        value = self.traverse(expr, indent='')
+        
+        if value.startswith('('):
+            value = value[1:-1].rstrip(" ") # Remove starting '(' and trailing ')' and additional spaces
+            if value == '': 
+                fmt = "%%c(%%p)" % () # args is empty
+            else:
+                if value.endswith(','): # if args has only one item
+                    value = value[:-1]
+                fmt = "%%c(%s, %%p)" % value
+        else:
+            fmt = "%%c(%s, %%p)" % value
+        
+        self.template_engine(
+            (fmt,
+            (0, 'expr'), (2, 'build_map_unpack_with_call', 100)), node)
+            
+        self.prune()
+    self.n_call_ex_kw = call_ex_kw
+
     def call_ex_kw2(node):
         """Handle CALL_FUNCTION_EX 2  (have KW) but with
         BUILD_{MAP,TUPLE}_UNPACK_WITH_CALL"""


### PR DESCRIPTION
As discussed in #227, for a better pythonic form we need implementing `n_call_ex_kw` for have form:

```
return testobj.testmethod(c, test='A', **extra_args)
```
instead of:
```
return testobj.testmethod(*(c,), test='A', **extra_args)
```
