### PR TITLE
Python 3.7 decompiling full lib

### DIFF
--- a/uncompyle6/parsers/parse37.py
+++ b/uncompyle6/parsers/parse37.py
@@ -32,6 +32,9 @@ class Python37Parser(Python36Parser):
         # Where does the POP_TOP really belong?
         stmt     ::= import37
         stmt     ::= async_for_stmt37
+        stmt     ::= for37
+
+
         import37 ::= import POP_TOP
 
         async_for_stmt     ::= SETUP_LOOP expr
@@ -132,6 +135,9 @@ class Python37Parser(Python36Parser):
         expr                       ::= if_exp_37b
         if_exp_37a                 ::= and_not expr JUMP_FORWARD COME_FROM expr COME_FROM
         if_exp_37b                 ::= expr jmp_false expr POP_JUMP_IF_FALSE jump_forward_else expr
+
+        for37                      ::= SETUP_LOOP expr for_iter store for_block POP_BLOCK
+
         """
 
     def customize_grammar_rules(self, tokens, customize):

--- a/uncompyle6/scanners/scanner3.py
+++ b/uncompyle6/scanners/scanner3.py
@@ -269,7 +269,13 @@ class Scanner3(Scanner):
                         come_from_type = opname[len('SETUP_'):]
                         come_from_name = 'COME_FROM_%s' % come_from_type
                         if self.version > 3.6:
-                            continue
+                            # Before 3.6 we allowed COME_FROMs appearing in places where they
+                            # weren't supposed to be to cope with our inability to get the grammar right.
+                            # After 3.6 we don't. So make sure the COME_FROM is placed at the location
+                            # where instruction jumping to it says it should be.
+                            if inst.offset != self.insts[self.offset2inst_index[jump_offset]].argval:
+                                continue
+                            pass
                         pass
                     elif inst.offset in self.except_targets:
                         come_from_name = 'COME_FROM_EXCEPT_CLAUSE'

--- a/uncompyle6/scanners/scanner3.py
+++ b/uncompyle6/scanners/scanner3.py
@@ -268,6 +268,8 @@ class Scanner3(Scanner):
                     if opname.startswith('SETUP_'):
                         come_from_type = opname[len('SETUP_'):]
                         come_from_name = 'COME_FROM_%s' % come_from_type
+                        if self.version > 3.6:
+                            continue
                         pass
                     elif inst.offset in self.except_targets:
                         come_from_name = 'COME_FROM_EXCEPT_CLAUSE'

--- a/uncompyle6/scanners/scanner3.py
+++ b/uncompyle6/scanners/scanner3.py
@@ -753,8 +753,10 @@ class Scanner3(Scanner):
                     # FIXME: this is not accurate The commented out below
                     # is what it should be. However grammar rules right now
                     # assume the incorrect offsets.
-                    # self.fixed_jumps[offset] = target
-                    self.fixed_jumps[offset] = pretarget.offset
+                    if self.version < 3.6:
+                        self.fixed_jumps[offset] = pretarget.offset
+                    else:
+                        self.fixed_jumps[offset] = target
                     self.structs.append({'type': 'and/or',
                                          'start': start,
                                          'end': pretarget.offset})

--- a/uncompyle6/semantics/customize37.py
+++ b/uncompyle6/semantics/customize37.py
@@ -67,9 +67,5 @@ def customize_for_version37(self, version):
             '%[3]{pattr.replace("-", " ")} %p %p', (0, 19), (6, 19) ),
         'if_exp_37a': ( '%p if %p else %p', (1, 'expr', 27), (0, 27), (4, 'expr', 27) ),
         'if_exp_37b': ( '%p if %p else %p', (2, 'expr', 27), (0, 'expr', 27), (5, 'expr', 27) ),
-        'for37':            (
-            '%|for %c in %c:\n%+%c%-\n\n',
-            (3, 'store'),
-            (1, 'expr'),
-            (4, 'for_block') ),
+
         })

--- a/uncompyle6/semantics/customize37.py
+++ b/uncompyle6/semantics/customize37.py
@@ -67,5 +67,9 @@ def customize_for_version37(self, version):
             '%[3]{pattr.replace("-", " ")} %p %p', (0, 19), (6, 19) ),
         'if_exp_37a': ( '%p if %p else %p', (1, 'expr', 27), (0, 27), (4, 'expr', 27) ),
         'if_exp_37b': ( '%p if %p else %p', (2, 'expr', 27), (0, 'expr', 27), (5, 'expr', 27) ),
-
+        'for37':            (
+            '%|for %c in %c:\n%+%c%-\n\n',
+            (3, 'store'),
+            (1, 'expr'),
+            (4, 'for_block') ),
         })


### PR DESCRIPTION
This is for getting ready for finalizing python 3.7 decompiler.

@rocky, Please check the `continue` for `COME_FROM_LOOP` in `scanner3.py` since i didn't find a proper way. Since we changed `COME_FROM` proc, `COME_FROM_LOOP` will be at it's correct location but i couldn't adjust a proper grammer for it.