### PR TITLE
feature #247: handle extra parenthesis in generators

### DIFF
--- a/uncompyle6/semantics/customize26_27.py
+++ b/uncompyle6/semantics/customize26_27.py
@@ -37,3 +37,22 @@ def customize_for_version26_27(self, version):
             'testtrue_then': ( 'not %p', (0, 22) ),
 
         })
+
+    def n_call(node):
+        mapping = self._get_mapping(node)
+        table = mapping[0]
+        key = node
+        for i in mapping[1:]:
+            key = key[i]
+            pass
+        if key.kind == 'CALL_FUNCTION_1':
+            args_node = node[-2]
+            if args_node == 'expr':
+                n = args_node[0]
+                if n == 'generator_exp':
+                    template = ('%c%P', 0, (1, -1, ', ', 100))
+                    self.template_engine(template, node)
+                    self.prune()
+
+        self.default(node)
+    self.n_call = n_call

--- a/uncompyle6/semantics/customize3.py
+++ b/uncompyle6/semantics/customize3.py
@@ -227,9 +227,38 @@ def customize_for_version3(self, version):
                                     -2, (-2-kwargs, -2, ', '))
                     self.template_engine(template, node)
                     self.prune()
+            elif key.kind == 'CALL_FUNCTION_1':
+                args_node = node[-2]
+                if args_node == 'pos_arg':
+                    assert args_node[0] == 'expr'
+                    n = args_node[0][0]
+                    if n == 'generator_exp':
+                        template = ('%c%P', 0, (1, -1, ', ', 100))
+                        self.template_engine(template, node)
+                        self.prune()
 
             self.default(node)
         self.n_call = n_call
+    elif version < 3.2:
+        def n_call(node):
+            mapping = self._get_mapping(node)
+            key = node
+            for i in mapping[1:]:
+                key = key[i]
+                pass
+            if key.kind == 'CALL_FUNCTION_1':
+                args_node = node[-2]
+                if args_node == 'pos_arg':
+                    assert args_node[0] == 'expr'
+                    n = args_node[0][0]
+                    if n == 'generator_exp':
+                        template = ('%c%P', 0, (1, -1, ', ', 100))
+                        self.template_engine(template, node)
+                        self.prune()
+
+            self.default(node)
+        self.n_call = n_call
+
 
 
     def n_mkfunc_annotate(node):

--- a/uncompyle6/semantics/customize35.py
+++ b/uncompyle6/semantics/customize35.py
@@ -112,6 +112,15 @@ def customize_for_version35(self, version):
                     template = ('*%c)', nargs+1)
                 self.template_engine(template, node)
             self.prune()
+        elif key.kind == 'CALL_FUNCTION_1':
+            args_node = node[-2]
+            if args_node == 'pos_arg':
+                assert args_node[0] == 'expr'
+                n = args_node[0][0]
+                if n == 'generator_exp':
+                    template = ('%c%P', 0, (1, -1, ', ', 100))
+                    self.template_engine(template, node)
+                    self.prune()
 
         self.default(node)
     self.n_call = n_call


### PR DESCRIPTION
As discussed in #247, for better formatting src, we are going to handle parenthesis in generators more accurate.

@rocky, as you can see due to `n_call` usage there were multiple cases to be changed. Is it ok to you?