### PR TITLE
[WIP] Handling if elif else more

### DIFF
--- a/uncompyle6/semantics/pysource.py
+++ b/uncompyle6/semantics/pysource.py
@@ -674,7 +674,7 @@ class SourceWalker(GenericASTTraversal, object):
             n = n[0][0]
         elif n[0].kind in ('lastc_stmt', 'lastl_stmt'):
             n = n[0]
-            if n[0].kind in ('ifstmt', 'iflaststmt', 'iflaststmtl', 'ifelsestmtl'):
+            if n[0].kind in ('ifstmt', 'iflaststmt', 'iflaststmtl', 'ifelsestmtl', 'ifelsestmtc'):
                 # This seems needed for Python 2.5-2.7
                 n = n[0]
                 pass
@@ -682,7 +682,7 @@ class SourceWalker(GenericASTTraversal, object):
         elif ( len(n) > 1 and 1 == len(n[0]) and n[0] == 'stmt'
                and n[1].kind == "stmt" ):
             else_suite_stmts = n[0]
-            if else_suite_stmts.kind not in ('ifstmt', 'iflaststmt', 'ifelsestmtl'):
+            if else_suite_stmts[0].kind not in ('ifstmt', 'iflaststmt', 'ifelsestmtl'):
                 if not preprocess:
                     self.default(node)
                 return


### PR DESCRIPTION
@x0ret 

Here is yet another transformation for handing `if .. `elif .. `else` which is more involved that occurs in Python 3.5 for this:

```python
x = 1
while 1:
    if x != 2:
        if __file__:
            x = 2
        elif __name__:
            pass
        else:
            break

while x != 2:
    if __file__:
        x = 2
    elif __name__:
        pass
    else:
        break
```

In a separate issue, Python 3.5 gets the `while 1` vs.`while x != 2` backwards, whiile python 3.4 turns them both into `while 1` and misses one of the the two `elif` opportunities.