### PR TITLE
Tree transforms for assert and elif

### DIFF
--- a/uncompyle6/bin/uncompile.py
+++ b/uncompyle6/bin/uncompile.py
@@ -46,10 +46,12 @@ Options:
   --help        show this message
 
 Debugging Options:
-  --asm     | -a  include byte-code       (disables --verify)
-  --grammar | -g  show matching grammar
-  --tree    | -t  include syntax tree     (disables --verify)
-  --tree++        add template rules to --tree when possible
+  --asm     | -a        include byte-code       (disables --verify)
+  --grammar | -g        show matching grammar
+  --tree={before|after}
+  -t {before|after}     include syntax before (or after) tree transformation
+                        (disables --verify)
+  --tree++ | -T         add template rules to --tree=before when possible
 
 Extensions of generated files:
   '.pyc_dis' '.pyo_dis'   successfully decompiled (and verified if --verify)
@@ -89,7 +91,7 @@ def main_bin():
     try:
         opts, pyc_paths = getopt.getopt(sys.argv[1:], 'hac:gtTdrVo:p:',
                                     'help asm compile= grammar linemaps recurse '
-                                    'timestamp tree tree+ '
+                                    'timestamp tree= tree+ '
                                     'fragments verify verify-run version '
                                     'weak-verify '
                                     'showgrammar encoding='.split(' '))
@@ -119,10 +121,19 @@ def main_bin():
             options['showasm'] = 'after'
             options['do_verify'] = None
         elif opt in ('--tree', '-t'):
-            options['showast'] = True
+            if 'showast' not in options:
+                options['showast'] = {}
+            if val == 'before':
+                options['showast'][val] = True
+            elif val == 'after':
+                options['showast'][val] = True
+            else:
+                options['showast']['before'] = True
             options['do_verify'] = None
         elif opt in ('--tree+', '-T'):
-            options['showast'] = 'Full'
+            if 'showast' not in options:
+                options['showast'] = {}
+            options['showast']['Full'] = True
             options['do_verify'] = None
         elif opt in ('--grammar', '-g'):
             options['showgrammar'] = True

--- a/uncompyle6/main.py
+++ b/uncompyle6/main.py
@@ -32,7 +32,7 @@ from xdis.load import load_module
 
 def _get_outstream(outfile):
     dir = os.path.dirname(outfile)
-    failed_file = outfile + '_failed'
+    failed_file = outfile + "_failed"
     if os.path.exists(failed_file):
         os.remove(failed_file)
     try:
@@ -40,15 +40,27 @@ def _get_outstream(outfile):
     except OSError:
         pass
     if PYTHON_VERSION < 3.0:
-        return open(outfile, mode='wb')
+        return open(outfile, mode="wb")
     else:
-        return open(outfile, mode='w', encoding='utf-8')
+        return open(outfile, mode="w", encoding="utf-8")
+
 
 def decompile(
-        bytecode_version, co, out=None, showasm=None, showast=False,
-        timestamp=None, showgrammar=False, source_encoding=None, code_objects={},
-        source_size=None, is_pypy=None, magic_int=None,
-        mapstream=None, do_fragments=False):
+    bytecode_version,
+    co,
+    out=None,
+    showasm=None,
+    showast={},
+    timestamp=None,
+    showgrammar=False,
+    source_encoding=None,
+    code_objects={},
+    source_size=None,
+    is_pypy=None,
+    magic_int=None,
+    mapstream=None,
+    do_fragments=False,
+):
     """
     ingests and deparses a given code block 'co'
 
@@ -64,81 +76,92 @@ def decompile(
     real_out = out or sys.stdout
 
     def write(s):
-        s += '\n'
+        s += "\n"
         real_out.write(s)
 
     assert iscode(co)
 
-    co_pypy_str = 'PyPy ' if is_pypy else ''
-    run_pypy_str = 'PyPy ' if IS_PYPY else ''
-    sys_version_lines = sys.version.split('\n')
+    co_pypy_str = "PyPy " if is_pypy else ""
+    run_pypy_str = "PyPy " if IS_PYPY else ""
+    sys_version_lines = sys.version.split("\n")
     if source_encoding:
-        write('# -*- coding: %s -*-' % source_encoding)
-    write('# uncompyle6 version %s\n'
-          '# %sPython bytecode %s%s\n# Decompiled from: %sPython %s' %
+        write("# -*- coding: %s -*-" % source_encoding)
+    write("# uncompyle6 version %s\n"
+          "# %sPython bytecode %s%s\n# Decompiled from: %sPython %s" %
           (VERSION, co_pypy_str, bytecode_version,
                " (%s)" % str(magic_int) if magic_int else "",
-          run_pypy_str, '\n# '.join(sys_version_lines)))
+          run_pypy_str, "\n# ".join(sys_version_lines)))
     if co.co_filename:
-        write('# Embedded file name: %s' % co.co_filename,)
+        write("# Embedded file name: %s" % co.co_filename)
     if timestamp:
-        write('# Compiled at: %s' % datetime.datetime.fromtimestamp(timestamp))
+        write("# Compiled at: %s" % datetime.datetime.fromtimestamp(timestamp))
     if source_size:
-        write('# Size of source mod 2**32: %d bytes' % source_size)
+        write("# Size of source mod 2**32: %d bytes" % source_size)
 
-    debug_opts = {
-        'asm': showasm,
-        'ast': showast,
-        'grammar': showgrammar
-    }
+    debug_opts = {"asm": showasm, "ast": showast, "grammar": showgrammar}
 
     try:
         if mapstream:
             if isinstance(mapstream, str):
                 mapstream = _get_outstream(mapstream)
 
-            deparsed = deparse_code_with_map(bytecode_version, co, out, showasm, showast,
-                                             showgrammar,
-                                             code_objects = code_objects,
-                                             is_pypy = is_pypy,
-                                             )
-            header_count = 3+len(sys_version_lines)
-            linemap = [(line_no, deparsed.source_linemap[line_no]+header_count)
-                        for line_no in
-                        sorted(deparsed.source_linemap.keys())]
+            deparsed = deparse_code_with_map(
+                bytecode_version,
+                co,
+                out,
+                showasm,
+                showast,
+                showgrammar,
+                code_objects=code_objects,
+                is_pypy=is_pypy,
+            )
+            header_count = 3 + len(sys_version_lines)
+            linemap = [
+                (line_no, deparsed.source_linemap[line_no] + header_count)
+                for line_no in sorted(deparsed.source_linemap.keys())
+            ]
             mapstream.write("\n\n# %s\n" % linemap)
         else:
             if do_fragments:
                 deparse_fn = code_deparse_fragments
             else:
                 deparse_fn = code_deparse
-            deparsed = deparse_fn(co, out, bytecode_version,
-                                  debug_opts = debug_opts,
-                                  is_pypy=is_pypy)
+            deparsed = deparse_fn(
+                co, out, bytecode_version, debug_opts=debug_opts, is_pypy=is_pypy
+            )
             pass
         return deparsed
     except pysource.SourceWalkerError as e:
         # deparsing failed
         raise pysource.SourceWalkerError(str(e))
 
+
 def compile_file(source_path):
-    if source_path.endswith('.py'):
+    if source_path.endswith(".py"):
         basename = source_path[:-3]
     else:
         basename = source_path
 
-    if hasattr(sys, 'pypy_version_info'):
+    if hasattr(sys, "pypy_version_info"):
         bytecode_path = "%s-pypy%s.pyc" % (basename, PYTHON_VERSION)
     else:
         bytecode_path = "%s-%s.pyc" % (basename, PYTHON_VERSION)
 
     print("compiling %s to %s" % (source_path, bytecode_path))
-    py_compile.compile(source_path, bytecode_path, 'exec')
+    py_compile.compile(source_path, bytecode_path, "exec")
     return bytecode_path
 
 
-def decompile_file(filename, outstream=None, showasm=None, showast=False,
-                   showgrammar=False, source_encoding=None, mapstream=None, do_fragments=False):
+def decompile_file(
+    filename,
+    outstream=None,
+    showasm=None,
+    showast={},
+    showgrammar=False,
+    source_encoding=None,
+    mapstream=None,
+    do_fragments=False,
+):
     """
     decompile Python byte-code file (.pyc). Return objects to
     all of the deparsed objects found in `filename`.
@@ -146,32 +169,68 @@ def decompile_file(filename, outstream=None, showasm=None, showast=False,
 
     filename = check_object_path(filename)
     code_objects = {}
-    (version, timestamp, magic_int, co, is_pypy,
-        source_size) = load_module(filename, code_objects)
+    (version, timestamp, magic_int, co, is_pypy, source_size) = load_module(
+        filename, code_objects
+    )
 
     if isinstance(co, list):
         deparsed = []
         for con in co:
             deparsed.append(
-                decompile(version, con, outstream, showasm, showast,
-                          timestamp, showgrammar, source_encoding, code_objects=code_objects,
-                          is_pypy=is_pypy, magic_int=magic_int),
-                          mapstream=mapstream)
+                decompile(
+                    version,
+                    con,
+                    outstream,
+                    showasm,
+                    showast,
+                    timestamp,
+                    showgrammar,
+                    source_encoding,
+                    code_objects=code_objects,
+                    is_pypy=is_pypy,
+                    magic_int=magic_int,
+                ),
+                mapstream=mapstream,
+            )
     else:
-        deparsed = [decompile(version, co, outstream, showasm, showast,
-                              timestamp, showgrammar, source_encoding,
-                              code_objects=code_objects, source_size=source_size,
-                              is_pypy=is_pypy, magic_int=magic_int,
-                              mapstream=mapstream, do_fragments=do_fragments)]
+        deparsed = [
+            decompile(
+                version,
+                co,
+                outstream,
+                showasm,
+                showast,
+                timestamp,
+                showgrammar,
+                source_encoding,
+                code_objects=code_objects,
+                source_size=source_size,
+                is_pypy=is_pypy,
+                magic_int=magic_int,
+                mapstream=mapstream,
+                do_fragments=do_fragments,
+            )
+        ]
     co = None
     return deparsed
 
 
 # FIXME: combine into an options parameter
-def main(in_base, out_base, compiled_files, source_files, outfile=None,
-         showasm=None, showast=False, do_verify=False,
-         showgrammar=False, source_encoding=None, raise_on_error=False,
-         do_linemaps=False, do_fragments=False):
+def main(
+    in_base,
+    out_base,
+    compiled_files,
+    source_files,
+    outfile=None,
+    showasm=None,
+    showast={},
+    do_verify=False,
+    showgrammar=False,
+    source_encoding=None,
+    raise_on_error=False,
+    do_linemaps=False,
+    do_fragments=False,
+):
     """
     in_base	base directory for input files
     out_base	base directory for output files (ignored when
@@ -194,49 +253,46 @@ def main(in_base, out_base, compiled_files, source_files, outfile=None,
         infile = os.path.join(in_base, filename)
         # print("XXX", infile)
         if not os.path.exists(infile):
-            sys.stderr.write("File '%s' doesn't exist. Skipped\n"
-                             % infile)
+            sys.stderr.write("File '%s' doesn't exist. Skipped\n" % infile)
             continue
 
         if do_linemaps:
-            linemap_stream = infile + '.pymap'
+            linemap_stream = infile + ".pymap"
             pass
 
         # print (infile, file=sys.stderr)
 
-        if outfile: # outfile was given as parameter
+        if outfile:  # outfile was given as parameter
             outstream = _get_outstream(outfile)
         elif out_base is None:
             outstream = sys.stdout
             if do_linemaps:
                 linemap_stream = sys.stdout
             if do_verify:
-                prefix = os.path.basename(filename) + '-'
-                if prefix.endswith('.py'):
-                    prefix = prefix[:-len('.py')]
+                prefix = os.path.basename(filename) + "-"
+                if prefix.endswith(".py"):
+                    prefix = prefix[: -len(".py")]
 
                 # Unbuffer output if possible
                 buffering = -1 if sys.stdout.isatty() else 0
                 if PYTHON_VERSION >= 3.5:
-                    t = tempfile.NamedTemporaryFile(mode='w+b',
-                                                    buffering=buffering,
-                                                    suffix='.py',
-                                                    prefix=prefix)
+                    t = tempfile.NamedTemporaryFile(
+                        mode="w+b", buffering=buffering, suffix=".py", prefix=prefix
+                    )
                 else:
-                    t = tempfile.NamedTemporaryFile(mode='w+b',
-                                                    suffix='.py',
-                                                    prefix=prefix)
+                    t = tempfile.NamedTemporaryFile(
+                        mode="w+b", suffix=".py", prefix=prefix
+                    )
                 current_outfile = t.name
-                sys.stdout = os.fdopen(sys.stdout.fileno(), 'w', buffering)
-                tee = subprocess.Popen(["tee", current_outfile],
-                                       stdin=subprocess.PIPE)
+                sys.stdout = os.fdopen(sys.stdout.fileno(), "w", buffering)
+                tee = subprocess.Popen(["tee", current_outfile], stdin=subprocess.PIPE)
                 os.dup2(tee.stdin.fileno(), sys.stdout.fileno())
                 os.dup2(tee.stdin.fileno(), sys.stderr.fileno())
         else:
-            if filename.endswith('.pyc'):
+            if filename.endswith(".pyc"):
                 current_outfile = os.path.join(out_base, filename[0:-1])
             else:
-                current_outfile = os.path.join(out_base, filename) + '_dis'
+                current_outfile = os.path.join(out_base, filename) + "_dis"
                 pass
             pass
 
@@ -246,15 +302,25 @@ def main(in_base, out_base, compiled_files, source_files, outfile=None,
 
         # Try to uncompile the input file
         try:
-            deparsed = decompile_file(infile, outstream, showasm, showast, showgrammar,
-                                      source_encoding, linemap_stream, do_fragments)
+            deparsed = decompile_file(
+                infile,
+                outstream,
+                showasm,
+                showast,
+                showgrammar,
+                source_encoding,
+                linemap_stream,
+                do_fragments,
+            )
             if do_fragments:
                 for d in deparsed:
                     last_mod = None
                     offsets = d.offsets
-                    for e in sorted([k for k in offsets.keys() if isinstance(k[1], int)]):
+                    for e in sorted(
+                        [k for k in offsets.keys() if isinstance(k[1], int)]
+                    ):
                         if e[0] != last_mod:
-                            line = '=' * len(e[0])
+                            line = "=" * len(e[0])
                             outstream.write("%s\n%s\n%s\n" % (line, e[0], line))
                         last_mod = e[0]
                         info = offsets[e]
@@ -279,9 +345,11 @@ def main(in_base, out_base, compiled_files, source_files, outfile=None,
             raise
         except RuntimeError as e:
             sys.stdout.write("\n%s\n" % str(e))
-            if str(e).startswith('Unsupported Python'):
+            if str(e).startswith("Unsupported Python"):
                 sys.stdout.write("\n")
-                sys.stderr.write("\n# Unsupported bytecode in file %s\n# %s\n" % (infile, e))
+                sys.stderr.write(
+                    "\n# Unsupported bytecode in file %s\n# %s\n" % (infile, e)
+                )
             else:
                 if outfile:
                     outstream.close()
@@ -294,26 +362,26 @@ def main(in_base, out_base, compiled_files, source_files, outfile=None,
         #     failed_files += 1
         #     if current_outfile:
         #         outstream.close()
-        #         os.rename(current_outfile, current_outfile + '_failed')
+        #         os.rename(current_outfile, current_outfile + "_failed")
         #     else:
         #         sys.stderr.write("\n# %s" % sys.exc_info()[1])
         #         sys.stderr.write("\n# Can't uncompile %s\n" % infile)
-        else: # uncompile successful
+        else:  # uncompile successful
             if current_outfile:
                 outstream.close()
 
                 if do_verify:
                     try:
-                        msg = verify.compare_code_with_srcfile(infile,
-                                                               current_outfile,
-                                                               do_verify)
+                        msg = verify.compare_code_with_srcfile(
+                            infile, current_outfile, do_verify
+                        )
                         if not current_outfile:
                             if not msg:
-                                print('\n# okay decompiling %s' % infile)
+                                print("\n# okay decompiling %s" % infile)
                                 okay_files += 1
                             else:
                                 verify_failed_files += 1
-                                print('\n# %s\n\t%s', infile, msg)
+                                print("\n# %s\n\t%s", infile, msg)
                                 pass
                         else:
                             okay_files += 1
@@ -321,7 +389,7 @@ def main(in_base, out_base, compiled_files, source_files, outfile=None,
                     except verify.VerifyCmpError as e:
                         print(e)
                         verify_failed_files += 1
-                        os.rename(current_outfile, current_outfile + '_unverified')
+                        os.rename(current_outfile, current_outfile + "_unverified")
                         sys.stderr.write("### Error Verifying %s\n" % filename)
                         sys.stderr.write(str(e) + "\n")
                         if not outfile:
@@ -334,18 +402,31 @@ def main(in_base, out_base, compiled_files, source_files, outfile=None,
                     okay_files += 1
                 pass
             elif do_verify:
-                sys.stderr.write("\n### uncompile successful, but no file to compare against\n")
+                sys.stderr.write(
+                    "\n### uncompile successful, but no file to compare against\n"
+                )
                 pass
             else:
                 okay_files += 1
                 if not current_outfile:
-                    mess = '\n# okay decompiling'
+                    mess = "\n# okay decompiling"
                     # mem_usage = __memUsage()
                     print(mess, infile)
         if current_outfile:
-            sys.stdout.write("%s -- %s\r" %
-                             (infile, status_msg(do_verify, tot_files, okay_files, failed_files,
-                                                 verify_failed_files, do_verify)))
+            sys.stdout.write(
+                "%s -- %s\r"
+                % (
+                    infile,
+                    status_msg(
+                        do_verify,
+                        tot_files,
+                        okay_files,
+                        failed_files,
+                        verify_failed_files,
+                        do_verify,
+                    ),
+                )
+            )
             try:
                 # FIXME: Something is weird with Pypy here
                 sys.stdout.flush()
@@ -364,24 +445,30 @@ def main(in_base, out_base, compiled_files, source_files, outfile=None,
 
 # ---- main ----
 
-if sys.platform.startswith('linux') and os.uname()[2][:2] in ['2.', '3.', '4.']:
+if sys.platform.startswith("linux") and os.uname()[2][:2] in ["2.", "3.", "4."]:
+
     def __memUsage():
-        mi = open('/proc/self/stat', 'r')
+        mi = open("/proc/self/stat", "r")
         mu = mi.readline().split()[22]
         mi.close()
         return int(mu) / 1000000
-else:
-    def __memUsage():
-        return ''
 
-def status_msg(do_verify, tot_files, okay_files, failed_files,
-               verify_failed_files, weak_verify):
-    if weak_verify == 'weak':
-        verification_type = 'weak '
-    elif weak_verify == 'verify-run':
-        verification_type = 'run '
+
+else:
+
+    def __memUsage():
+        return ""
+
+
+def status_msg(
+    do_verify, tot_files, okay_files, failed_files, verify_failed_files, weak_verify
+):
+    if weak_verify == "weak":
+        verification_type = "weak "
+    elif weak_verify == "verify-run":
+        verification_type = "run "
     else:
-        verification_type = ''
+        verification_type = ""
     if tot_files == 1:
         if failed_files:
             return "\n# decompile failed"
@@ -391,7 +478,11 @@ def status_msg(do_verify, tot_files, okay_files, failed_files,
             return "\n# Successfully decompiled file"
             pass
         pass
-    mess = "decompiled %i files: %i okay, %i failed" % (tot_files, okay_files, failed_files)
+    mess = "decompiled %i files: %i okay, %i failed" % (
+        tot_files,
+        okay_files,
+        failed_files,
+    )
     if do_verify:
-        mess += (", %i %sverification failed" % (verify_failed_files, verification_type))
+        mess += ", %i %sverification failed" % (verify_failed_files, verification_type)
     return mess

--- a/uncompyle6/parsers/treenode.py
+++ b/uncompyle6/parsers/treenode.py
@@ -7,13 +7,16 @@ if PYTHON3:
     intern = sys.intern
 
 class SyntaxTree(spark_AST):
+    def __init__(self, *args, **kwargs):
+        super(SyntaxTree, self).__init__(*args, **kwargs)
+
     def isNone(self):
         """An SyntaxTree None token. We can't use regular list comparisons
         because SyntaxTree token offsets might be different"""
         return len(self.data) == 1 and NoneToken == self.data[0]
 
     def __repr__(self):
-        return self.__repr1__('', None)
+        return self.__repr1__("", None)
 
     def __repr1__(self, indent, sibNum=None):
         rv = str(self.kind)
@@ -23,17 +26,22 @@ class SyntaxTree(spark_AST):
         if len(self) > 1:
             rv += " (%d)" % (len(self))
             enumerate_children = True
+        # if self.transformed_by is not None:
+        #     if self.transformed_by is True:
+        #         rv += " (transformed)"
+        #     else:
+        #         rv += " (transformed by %s)" % self.transformed_by
         rv = indent + rv
-        indent += '    '
+        indent += "    "
         i = 0
         for node in self:
-            if hasattr(node, '__repr1__'):
+            if hasattr(node, "__repr1__"):
                 if enumerate_children:
-                    child =  node.__repr1__(indent, i)
+                    child = node.__repr1__(indent, i)
                 else:
                     child = node.__repr1__(indent, None)
             else:
-                inst = node.format(line_prefix='L.')
+                inst = node.format(line_prefix="L.")
                 if inst.startswith("\n"):
                     # Nuke leading \n
                     inst = inst[1:]

--- a/uncompyle6/semantics/make_function.py
+++ b/uncompyle6/semantics/make_function.py
@@ -1,4 +1,4 @@
-#  Copyright (c) 2015-2018 by Rocky Bernstein
+#  Copyright (c) 2015-2019 by Rocky Bernstein
 #  Copyright (c) 2000-2002 by hartmut Goebel <h.goebel@crazy-compilers.com>
 #
 #  This program is free software: you can redistribute it and/or modify
@@ -23,8 +23,11 @@ from uncompyle6 import PYTHON3
 from uncompyle6.semantics.parser_error import ParserError
 from uncompyle6.parser import ParserError as ParserError2
 from uncompyle6.semantics.helper import (
-    print_docstring, find_all_globals, find_globals_and_nonlocals, find_none
-    )
+    print_docstring,
+    find_all_globals,
+    find_globals_and_nonlocals,
+    find_none,
+)
 
 if PYTHON3:
     from itertools import zip_longest
@@ -35,8 +38,10 @@ from uncompyle6.show import maybe_show_tree_param_default
 
 # FIXME: DRY the below code...
 
-def make_function3_annotate(self, node, is_lambda, nested=1,
-                            code_node=None, annotate_last=-1):
+
+def make_function3_annotate(
+    self, node, is_lambda, nested=1, code_node=None, annotate_last=-1
+):
     """
     Dump function defintion, doc string, and function
     body. This code is specialized for Python 3"""
@@ -47,33 +52,35 @@ def make_function3_annotate(self, node, is_lambda, nested=1,
             - handle format tuple parameters
         """
         if default:
-            value = self.traverse(default, indent='')
+            value = self.traverse(default, indent="")
             maybe_show_tree_param_default(self, name, value)
-            result = '%s=%s' % (name,  value)
-            if result[-2:] == '= ':	# default was 'LOAD_CONST None'
-                result += 'None'
+            result = "%s=%s" % (name, value)
+            if result[-2:] == "= ":  # default was 'LOAD_CONST None'
+                result += "None"
             return result
         else:
             return name
 
     # MAKE_FUNCTION_... or MAKE_CLOSURE_...
-    assert node[-1].kind.startswith('MAKE_')
+    assert node[-1].kind.startswith("MAKE_")
 
     annotate_tuple = None
-    for annotate_last in range(len(node)-1, -1, -1):
-        if node[annotate_last] == 'annotate_tuple':
+    for annotate_last in range(len(node) - 1, -1, -1):
+        if node[annotate_last] == "annotate_tuple":
             annotate_tuple = node[annotate_last]
             break
     annotate_args = {}
 
-    if (annotate_tuple == 'annotate_tuple'
-        and annotate_tuple[0] in ('LOAD_CONST', 'LOAD_NAME')
-        and isinstance(annotate_tuple[0].attr, tuple)):
+    if (
+        annotate_tuple == "annotate_tuple"
+        and annotate_tuple[0] in ("LOAD_CONST", "LOAD_NAME")
+        and isinstance(annotate_tuple[0].attr, tuple)
+    ):
         annotate_tup = annotate_tuple[0].attr
         i = -1
-        j = annotate_last-1
+        j = annotate_last - 1
         l = -len(node)
-        while j >= l and node[j].kind in ('annotate_arg' 'annotate_tuple'):
+        while j >= l and node[j].kind in ("annotate_arg" "annotate_tuple"):
             annotate_args[annotate_tup[i]] = node[j][0]
             i -= 1
             j -= 1
@@ -81,20 +88,20 @@ def make_function3_annotate(self, node, is_lambda, nested=1,
     args_node = node[-1]
     if isinstance(args_node.attr, tuple):
         # positional args are before kwargs
-        defparams = node[:args_node.attr[0]]
-        pos_args, kw_args, annotate_argc  = args_node.attr
-        if 'return' in annotate_args.keys():
+        defparams = node[: args_node.attr[0]]
+        pos_args, kw_args, annotate_argc = args_node.attr
+        if "return" in annotate_args.keys():
             annotate_argc = len(annotate_args) - 1
     else:
-        defparams = node[:args_node.attr]
-        kw_args  = 0
+        defparams = node[: args_node.attr]
+        kw_args = 0
         annotate_argc = 0
         pass
 
     annotate_dict = {}
 
     for name in annotate_args.keys():
-        n = self.traverse(annotate_args[name], indent='')
+        n = self.traverse(annotate_args[name], indent="")
         annotate_dict[name] = n
 
     if 3.0 <= self.version <= 3.2:
@@ -105,7 +112,7 @@ def make_function3_annotate(self, node, is_lambda, nested=1,
         lambda_index = None
 
     if lambda_index and is_lambda and iscode(node[lambda_index].attr):
-        assert node[lambda_index].kind == 'LOAD_LAMBDA'
+        assert node[lambda_index].kind == "LOAD_LAMBDA"
         code = node[lambda_index].attr
     else:
         code = code_node.attr
@@ -119,13 +126,15 @@ def make_function3_annotate(self, node, is_lambda, nested=1,
 
     paramnames = list(code.co_varnames[:argc])
     if kwonlyargcount > 0:
-        kwargs = list(code.co_varnames[argc:argc+kwonlyargcount])
+        kwargs = list(code.co_varnames[argc : argc + kwonlyargcount])
 
     try:
-        ast = self.build_ast(code._tokens,
-                             code._customize,
-                             is_lambda = is_lambda,
-                             noneInNames = ('None' in code.co_names))
+        ast = self.build_ast(
+            code._tokens,
+            code._customize,
+            is_lambda=is_lambda,
+            noneInNames=("None" in code.co_names),
+        )
     except (ParserError, ParserError2) as p:
         self.write(str(p))
         if not self.tolerate_errors:
@@ -142,20 +151,20 @@ def make_function3_annotate(self, node, is_lambda, nested=1,
 
     last_line = self.f.getvalue().split("\n")[-1]
     l = len(last_line)
-    indent = ' ' * l
+    indent = " " * l
     line_number = self.line_number
 
     i = len(paramnames) - len(defparams)
-    suffix = ''
+    suffix = ""
 
     no_paramnames = len(paramnames[:i]) == 0
 
     for param in paramnames[:i]:
         self.write(suffix, param)
-        suffix = ', '
+        suffix = ", "
         if param in annotate_dict:
-            self.write(': %s' % annotate_dict[param])
-            if (line_number != self.line_number):
+            self.write(": %s" % annotate_dict[param])
+            if line_number != self.line_number:
                 suffix = ",\n" + indent
                 line_number = self.line_number
             # value, string = annotate_args[param]
@@ -164,10 +173,9 @@ def make_function3_annotate(self, node, is_lambda, nested=1,
             # else:
             #     self.write(': %s' % value)
 
-
-    suffix = ', ' if i > 0 else ''
+    suffix = ", " if i > 0 else ""
     for n in node:
-        if n == 'pos_arg':
+        if n == "pos_arg":
             no_paramnames = False
             self.write(suffix)
             param = paramnames[i]
@@ -178,25 +186,24 @@ def make_function3_annotate(self, node, is_lambda, nested=1,
                     aa = aa[0]
                     self.write(': "%s"' % aa)
                 elif isinstance(aa, SyntaxTree):
-                    self.write(': ')
+                    self.write(": ")
                     self.preorder(aa)
 
-            self.write('=')
+            self.write("=")
             i += 1
             self.preorder(n)
-            if (line_number != self.line_number):
+            if line_number != self.line_number:
                 suffix = ",\n" + indent
                 line_number = self.line_number
             else:
-                suffix = ', '
-
+                suffix = ", "
 
     if code_has_star_arg(code):
         star_arg = code.co_varnames[argc + kwonlyargcount]
         if annotate_dict and star_arg in annotate_dict:
-            self.write(suffix, '*%s: %s' % (star_arg, annotate_dict[star_arg]))
+            self.write(suffix, "*%s: %s" % (star_arg, annotate_dict[star_arg]))
         else:
-            self.write(suffix, '*%s' % star_arg)
+            self.write(suffix, "*%s" % star_arg)
         argc += 1
 
     # self.println(indent, '#flags:\t', int(code.co_flags))
@@ -214,22 +221,22 @@ def make_function3_annotate(self, node, is_lambda, nested=1,
             ends_in_comma = True
         else:
             if argc > 0:
-                self.write(', ')
+                self.write(", ")
                 ends_in_comma = True
 
         kw_args = [None] * kwonlyargcount
 
         for n in node:
-            if n == 'kwargs':
+            if n == "kwargs":
                 n = n[0]
-            if n == 'kwarg':
+            if n == "kwarg":
                 name = eval(n[0].pattr)
                 idx = kwargs.index(name)
-                default = self.traverse(n[1], indent='')
+                default = self.traverse(n[1], indent="")
                 if annotate_dict and name in annotate_dict:
-                    kw_args[idx] = '%s: %s=%s' % (name, annotate_dict[name], default)
+                    kw_args[idx] = "%s: %s=%s" % (name, annotate_dict[name], default)
                 else:
-                    kw_args[idx] = '%s=%s' % (name, default)
+                    kw_args[idx] = "%s=%s" % (name, default)
                 pass
             pass
 
@@ -239,11 +246,11 @@ def make_function3_annotate(self, node, is_lambda, nested=1,
             if flag:
                 n = kwargs[i]
                 if n in annotate_dict:
-                    kw_args[i] = "%s: %s" %(n, annotate_dict[n])
+                    kw_args[i] = "%s: %s" % (n, annotate_dict[n])
                 else:
                     kw_args[i] = "%s" % n
 
-        self.write(', '.join(kw_args), ', ')
+        self.write(", ".join(kw_args), ", ")
 
     else:
         if argc == 0:
@@ -251,52 +258,54 @@ def make_function3_annotate(self, node, is_lambda, nested=1,
 
     if code_has_star_star_arg(code):
         if not ends_in_comma:
-            self.write(', ')
+            self.write(", ")
         star_star_arg = code.co_varnames[argc + kwonlyargcount]
         if annotate_dict and star_star_arg in annotate_dict:
-            self.write('**%s: %s' % (star_star_arg, annotate_dict[star_star_arg]))
+            self.write("**%s: %s" % (star_star_arg, annotate_dict[star_star_arg]))
         else:
-            self.write('**%s' % star_star_arg)
+            self.write("**%s" % star_star_arg)
 
     if is_lambda:
         self.write(": ")
     else:
-        self.write(')')
-        if 'return' in annotate_tuple[0].attr:
+        self.write(")")
+        if "return" in annotate_tuple[0].attr:
             if (line_number != self.line_number) and not no_paramnames:
                 self.write("\n" + indent)
                 line_number = self.line_number
-            self.write(' -> ')
+            self.write(" -> ")
             # value, string = annotate_args['return']
             # if string:
             #     self.write(' -> "%s"' % value)
             # else:
             #     self.write(' -> %s' % value)
-            self.preorder(node[annotate_last-1])
+            self.preorder(node[annotate_last - 1])
 
         self.println(":")
 
-    if (len(code.co_consts) > 0 and
-        code.co_consts[0] is not None and not is_lambda): # ugly
+    if node[-2] == "docstring" and not is_lambda:
         # docstring exists, dump it
-        print_docstring(self, self.indent, code.co_consts[0])
+        self.println(self.traverse(node[-2]))
 
-    code._tokens = None # save memory
-    assert ast == 'stmts'
+    code._tokens = None  # save memory
+    assert ast == "stmts"
 
     all_globals = find_all_globals(ast, set())
-    globals, nonlocals = find_globals_and_nonlocals(ast, set(), set(),
-                                                    code, self.version)
+    globals, nonlocals = find_globals_and_nonlocals(
+        ast, set(), set(), code, self.version
+    )
     for g in sorted((all_globals & self.mod_globs) | globals):
-        self.println(self.indent, 'global ', g)
+        self.println(self.indent, "global ", g)
     for nl in sorted(nonlocals):
-        self.println(self.indent, 'nonlocal ', nl)
+        self.println(self.indent, "nonlocal ", nl)
     self.mod_globs -= all_globals
-    has_none = 'None' in code.co_names
+    has_none = "None" in code.co_names
     rn = has_none and not find_none(ast)
-    self.gen_source(ast, code.co_name, code._customize, is_lambda=is_lambda,
-                    returnNone=rn)
-    code._tokens = code._customize = None # save memory
+    self.gen_source(
+        ast, code.co_name, code._customize, is_lambda=is_lambda, returnNone=rn
+    )
+    code._tokens = code._customize = None  # save memory
+
 
 def make_function2(self, node, is_lambda, nested=1, code_node=None):
     """
@@ -314,38 +323,38 @@ def make_function2(self, node, is_lambda, nested=1, code_node=None):
         """
         # if formal parameter is a tuple, the paramater name
         # starts with a dot (eg. '.1', '.2')
-        if name.startswith('.'):
+        if name.startswith("."):
             # replace the name with the tuple-string
             name = self.get_tuple_parameter(ast, name)
             pass
 
         if default:
-            value = self.traverse(default, indent='')
+            value = self.traverse(default, indent="")
             maybe_show_tree_param_default(self.showast, name, value)
-            result = '%s=%s' % (name,  value)
-            if result[-2:] == '= ':	# default was 'LOAD_CONST None'
-                result += 'None'
+            result = "%s=%s" % (name, value)
+            if result[-2:] == "= ":  # default was 'LOAD_CONST None'
+                result += "None"
             return result
         else:
             return name
 
     # MAKE_FUNCTION_... or MAKE_CLOSURE_...
-    assert node[-1].kind.startswith('MAKE_')
+    assert node[-1].kind.startswith("MAKE_")
 
     args_node = node[-1]
     if isinstance(args_node.attr, tuple):
         # positional args are after kwargs
-        defparams = node[1:args_node.attr[0]+1]
-        pos_args, kw_args, annotate_argc  = args_node.attr
+        defparams = node[1 : args_node.attr[0] + 1]
+        pos_args, kw_args, annotate_argc = args_node.attr
     else:
-        defparams = node[:args_node.attr]
-        kw_args  = 0
+        defparams = node[: args_node.attr]
+        kw_args = 0
         pass
 
     lambda_index = None
 
     if lambda_index and is_lambda and iscode(node[lambda_index].attr):
-        assert node[lambda_index].kind == 'LOAD_LAMBDA'
+        assert node[lambda_index].kind == "LOAD_LAMBDA"
         code = node[lambda_index].attr
     else:
         code = code_node.attr
@@ -358,13 +367,16 @@ def make_function2(self, node, is_lambda, nested=1, code_node=None):
     paramnames = list(code.co_varnames[:argc])
 
     # defaults are for last n parameters, thus reverse
-    paramnames.reverse(); defparams.reverse()
+    paramnames.reverse()
+    defparams.reverse()
 
     try:
-        ast = self.build_ast(code._tokens,
-                             code._customize,
-                             is_lambda = is_lambda,
-                             noneInNames = ('None' in code.co_names))
+        ast = self.build_ast(
+            code._tokens,
+            code._customize,
+            is_lambda=is_lambda,
+            noneInNames=("None" in code.co_names),
+        )
     except (ParserError, ParserError2) as p:
         self.write(str(p))
         if not self.tolerate_errors:
@@ -375,12 +387,14 @@ def make_function2(self, node, is_lambda, nested=1, code_node=None):
     indent = self.indent
 
     # build parameters
-    params = [build_param(ast, name, default) for
-              name, default in zip_longest(paramnames, defparams, fillvalue=None)]
-    params.reverse() # back to correct order
+    params = [
+        build_param(ast, name, default)
+        for name, default in zip_longest(paramnames, defparams, fillvalue=None)
+    ]
+    params.reverse()  # back to correct order
 
     if code_has_star_arg(code):
-        params.append('*%s' % code.co_varnames[argc])
+        params.append("*%s" % code.co_varnames[argc])
         argc += 1
 
     # dump parameter list (with default values)
@@ -392,13 +406,15 @@ def make_function2(self, node, is_lambda, nested=1, code_node=None):
         # drop the (return) None since that was just put there
         # to have something to after the yield finishes.
         # FIXME: this is a bit hoaky and not general
-        if (len(ast) > 1 and
-            self.traverse(ast[-1]) == 'None' and
-            self.traverse(ast[-2]).strip().startswith('yield')):
+        if (
+            len(ast) > 1
+            and self.traverse(ast[-1]) == "None"
+            and self.traverse(ast[-2]).strip().startswith("yield")
+        ):
             del ast[-1]
             # Now pick out the expr part of the last statement
             ast_expr = ast[-1]
-            while ast_expr.kind != 'expr':
+            while ast_expr.kind != "expr":
                 ast_expr = ast_expr[0]
             ast[-1] = ast_expr
             pass
@@ -416,7 +432,7 @@ def make_function2(self, node, is_lambda, nested=1, code_node=None):
             self.write(", ")
 
         for n in node:
-            if n == 'pos_arg':
+            if n == "pos_arg":
                 continue
             else:
                 self.preorder(n)
@@ -425,38 +441,41 @@ def make_function2(self, node, is_lambda, nested=1, code_node=None):
 
     if code_has_star_star_arg(code):
         if argc > 0:
-            self.write(', ')
-        self.write('**%s' % code.co_varnames[argc + kw_pairs])
+            self.write(", ")
+        self.write("**%s" % code.co_varnames[argc + kw_pairs])
 
     if is_lambda:
         self.write(": ")
     else:
         self.println("):")
 
-    if len(code.co_consts) > 0 and code.co_consts[0] is not None and not is_lambda: # ugly
+    if node[-2] == "docstring" and not is_lambda:
         # docstring exists, dump it
         print_docstring(self, indent, code.co_consts[0])
 
-    code._tokens = None # save memory
+    code._tokens = None  # save memory
     if not is_lambda:
-        assert ast == 'stmts'
+        assert ast == "stmts"
 
     all_globals = find_all_globals(ast, set())
 
-    globals, nonlocals = find_globals_and_nonlocals(ast, set(), set(),
-                                                    code, self.version)
+    globals, nonlocals = find_globals_and_nonlocals(
+        ast, set(), set(), code, self.version
+    )
 
     # Python 2 doesn't support the "nonlocal" statement
     assert self.version >= 3.0 or not nonlocals
 
     for g in sorted((all_globals & self.mod_globs) | globals):
-        self.println(self.indent, 'global ', g)
+        self.println(self.indent, "global ", g)
     self.mod_globs -= all_globals
-    has_none = 'None' in code.co_names
+    has_none = "None" in code.co_names
     rn = has_none and not find_none(ast)
-    self.gen_source(ast, code.co_name, code._customize, is_lambda=is_lambda,
-                    returnNone=rn)
-    code._tokens = None; code._customize = None # save memory
+    self.gen_source(
+        ast, code.co_name, code._customize, is_lambda=is_lambda, returnNone=rn
+    )
+    code._tokens = None
+    code._customize = None  # save memory
 
 
 def make_function3(self, node, is_lambda, nested=1, code_node=None):
@@ -500,23 +519,23 @@ def make_function3(self, node, is_lambda, nested=1, code_node=None):
         if self.version >= 3.6:
             value = default
         else:
-            value = self.traverse(default, indent='')
+            value = self.traverse(default, indent="")
         maybe_show_tree_param_default(self.showast, name, value)
         if annotation:
-            result = '%s: %s=%s' % (name, annotation, value)
+            result = "%s: %s=%s" % (name, annotation, value)
         else:
-            result = '%s=%s' % (name, value)
+            result = "%s=%s" % (name, value)
 
         # The below can probably be removed. This is probably
         # a holdover from days when LOAD_CONST erroneously
         # didn't handle LOAD_CONST None properly
-        if result[-2:] == '= ':	# default was 'LOAD_CONST None'
-            result += 'None'
+        if result[-2:] == "= ":  # default was 'LOAD_CONST None'
+            result += "None"
 
         return result
 
     # MAKE_FUNCTION_... or MAKE_CLOSURE_...
-    assert node[-1].kind.startswith('MAKE_')
+    assert node[-1].kind.startswith("MAKE_")
 
     # Python 3.3+ adds a qualified name at TOS (-1)
     # moving down the LOAD_LAMBDA instruction
@@ -536,11 +555,13 @@ def make_function3(self, node, is_lambda, nested=1, code_node=None):
     # not to be confused with keyword parameters which may appear after *.
     args_attr = args_node.attr
 
-    if isinstance(args_attr, tuple) or (self.version >= 3.6 and isinstance(args_attr, list)):
+    if isinstance(args_attr, tuple) or (
+        self.version >= 3.6 and isinstance(args_attr, list)
+    ):
         if len(args_attr) == 3:
-            pos_args, kw_args, annotate_argc  = args_attr
+            pos_args, kw_args, annotate_argc = args_attr
         else:
-            pos_args, kw_args, annotate_argc, closure  = args_attr
+            pos_args, kw_args, annotate_argc, closure = args_attr
 
             i = -4
             kw_pairs = 0
@@ -550,86 +571,103 @@ def make_function3(self, node, is_lambda, nested=1, code_node=None):
             if annotate_argc:
                 # Turn into subroutine and DRY with other use
                 annotate_node = node[i]
-                if annotate_node == 'expr':
+                if annotate_node == "expr":
                     annotate_node = annotate_node[0]
                     annotate_name_node = annotate_node[-1]
-                    if annotate_node == 'dict' and annotate_name_node.kind.startswith('BUILD_CONST_KEY_MAP'):
-                        types = [self.traverse(n, indent='') for n in annotate_node[:-2]]
+                    if annotate_node == "dict" and annotate_name_node.kind.startswith(
+                        "BUILD_CONST_KEY_MAP"
+                    ):
+                        types = [
+                            self.traverse(n, indent="") for n in annotate_node[:-2]
+                        ]
                         names = annotate_node[-2].attr
                         l = len(types)
                         assert l == len(names)
-                        for i in range(l): annotate_dict[names[i]] = types[i]
+                        for i in range(l):
+                            annotate_dict[names[i]] = types[i]
                         pass
                     pass
                 i -= 1
             if kw_args:
                 kw_node = node[i]
-                if kw_node == 'expr':
+                if kw_node == "expr":
                     kw_node = kw_node[0]
-                if kw_node == 'dict':
+                if kw_node == "dict":
                     kw_pairs = kw_node[-1].attr
 
-
         # FIXME: there is probably a better way to classify this.
-        have_kwargs = node[0].kind.startswith('kwarg') or node[0] == 'no_kwargs'
+        have_kwargs = node[0].kind.startswith("kwarg") or node[0] == "no_kwargs"
         if len(node) >= 4:
             lc_index = -4
         else:
             lc_index = -3
             pass
 
-        if (3.0 <= self.version <= 3.3 and len(node) > 2 and
-                node[lambda_index] != 'LOAD_LAMBDA' and
-                (have_kwargs or node[lc_index].kind != 'load_closure')):
+        if (
+            3.0 <= self.version <= 3.3
+            and len(node) > 2
+            and node[lambda_index] != "LOAD_LAMBDA"
+            and (have_kwargs or node[lc_index].kind != "load_closure")
+        ):
 
             # Find the index in "node" where the first default
             # parameter value is located. Note this is in contrast to
             # key-word arguments, pairs of (name, value), which appear after "*".
             # "default_values_start" is this location.
             default_values_start = 0
-            if node[0] == 'no_kwargs':
+            if node[0] == "no_kwargs":
                 default_values_start += 1
             # args are after kwargs; kwargs are bundled as one node
-            if node[default_values_start] == 'kwargs':
+            if node[default_values_start] == "kwargs":
                 default_values_start += 1
-            defparams = node[default_values_start:default_values_start+args_node.attr[0]]
+            defparams = node[
+                default_values_start : default_values_start + args_node.attr[0]
+            ]
         else:
             if self.version < 3.6:
-                defparams = node[:args_node.attr[0]]
-                kw_args  = 0
+                defparams = node[: args_node.attr[0]]
+                kw_args = 0
             else:
                 defparams = []
                 # FIXME: DRY with code below
                 default, kw_args, annotate_argc = args_node.attr[0:3]
                 if default:
                     expr_node = node[0]
-                    if node[0] == 'pos_arg':
+                    if node[0] == "pos_arg":
                         expr_node = expr_node[0]
-                    assert expr_node == 'expr', "expecting mkfunc default node to be an expr"
-                    if (expr_node[0] == 'LOAD_CONST' and
-                        isinstance(expr_node[0].attr, tuple)):
+                    assert (
+                        expr_node == "expr"
+                    ), "expecting mkfunc default node to be an expr"
+                    if expr_node[0] == "LOAD_CONST" and isinstance(
+                        expr_node[0].attr, tuple
+                    ):
                         defparams = [repr(a) for a in expr_node[0].attr]
-                    elif expr_node[0] in frozenset(('list', 'tuple', 'dict', 'set')):
-                        defparams =  [self.traverse(n, indent='') for n in expr_node[0][:-1]]
+                    elif expr_node[0] in frozenset(("list", "tuple", "dict", "set")):
+                        defparams = [
+                            self.traverse(n, indent="") for n in expr_node[0][:-1]
+                        ]
                 else:
                     defparams = []
                 pass
     else:
         if self.version < 3.6:
-            defparams = node[:args_node.attr]
-            kw_args  = 0
+            defparams = node[: args_node.attr]
+            kw_args = 0
         else:
             default, kw_args, annotate, closure = args_node.attr
             if default:
                 expr_node = node[0]
-                if node[0] == 'pos_arg':
+                if node[0] == "pos_arg":
                     expr_node = expr_node[0]
-                assert expr_node == 'expr', "expecting mkfunc default node to be an expr"
-                if (expr_node[0] == 'LOAD_CONST' and
-                    isinstance(expr_node[0].attr, tuple)):
+                assert (
+                    expr_node == "expr"
+                ), "expecting mkfunc default node to be an expr"
+                if expr_node[0] == "LOAD_CONST" and isinstance(
+                    expr_node[0].attr, tuple
+                ):
                     defparams = [repr(a) for a in expr_node[0].attr]
-                elif expr_node[0] in frozenset(('list', 'tuple', 'dict', 'set')):
-                    defparams =  [self.traverse(n, indent='') for n in expr_node[0][:-1]]
+                elif expr_node[0] in frozenset(("list", "tuple", "dict", "set")):
+                    defparams = [self.traverse(n, indent="") for n in expr_node[0][:-1]]
             else:
                 defparams = []
 
@@ -642,28 +680,33 @@ def make_function3(self, node, is_lambda, nested=1, code_node=None):
             if annotate_argc:
                 # Turn into subroutine and DRY with other use
                 annotate_node = node[i]
-                if annotate_node == 'expr':
+                if annotate_node == "expr":
                     annotate_node = annotate_node[0]
                     annotate_name_node = annotate_node[-1]
-                    if annotate_node == 'dict' and annotate_name_node.kind.startswith('BUILD_CONST_KEY_MAP'):
-                        types = [self.traverse(n, indent='') for n in annotate_node[:-2]]
+                    if annotate_node == "dict" and annotate_name_node.kind.startswith(
+                        "BUILD_CONST_KEY_MAP"
+                    ):
+                        types = [
+                            self.traverse(n, indent="") for n in annotate_node[:-2]
+                        ]
                         names = annotate_node[-2].attr
                         l = len(types)
                         assert l == len(names)
-                        for i in range(l): annotate_dict[names[i]] = types[i]
+                        for i in range(l):
+                            annotate_dict[names[i]] = types[i]
                         pass
                     pass
                 i -= 1
             if kw_args:
                 kw_node = node[i]
-                if kw_node == 'expr':
+                if kw_node == "expr":
                     kw_node = kw_node[0]
-                if kw_node == 'dict':
+                if kw_node == "dict":
                     kw_pairs = kw_node[-1].attr
         pass
 
     if lambda_index and is_lambda and iscode(node[lambda_index].attr):
-        assert node[lambda_index].kind == 'LOAD_LAMBDA'
+        assert node[lambda_index].kind == "LOAD_LAMBDA"
         code = node[lambda_index].attr
     else:
         code = code_node.attr
@@ -677,17 +720,19 @@ def make_function3(self, node, is_lambda, nested=1, code_node=None):
 
     paramnames = list(scanner_code.co_varnames[:argc])
     if kwonlyargcount > 0:
-        kwargs = list(scanner_code.co_varnames[argc:argc+kwonlyargcount])
+        kwargs = list(scanner_code.co_varnames[argc : argc + kwonlyargcount])
 
     # defaults are for last n parameters, thus reverse
-    paramnames.reverse();
+    paramnames.reverse()
     defparams.reverse()
 
     try:
-        ast = self.build_ast(scanner_code._tokens,
-                             scanner_code._customize,
-                             is_lambda = is_lambda,
-                             noneInNames = ('None' in code.co_names))
+        ast = self.build_ast(
+            scanner_code._tokens,
+            scanner_code._customize,
+            is_lambda=is_lambda,
+            noneInNames=("None" in code.co_names),
+        )
     except (ParserError, ParserError2) as p:
         self.write(str(p))
         if not self.tolerate_errors:
@@ -707,10 +752,13 @@ def make_function3(self, node, is_lambda, nested=1, code_node=None):
     params = []
     if defparams:
         for i, defparam in enumerate(defparams):
-            params.append(build_param(ast, paramnames[i], defparam,
-                                      annotate_dict.get(paramnames[i])))
+            params.append(
+                build_param(
+                    ast, paramnames[i], defparam, annotate_dict.get(paramnames[i])
+                )
+            )
 
-        for param in paramnames[i+1:]:
+        for param in paramnames[i + 1 :]:
             if param in annotate_dict:
                 params.append("%s: %s" % (param, annotate_dict[param]))
             else:
@@ -722,17 +770,17 @@ def make_function3(self, node, is_lambda, nested=1, code_node=None):
             else:
                 params.append(param)
 
-    params.reverse() # back to correct order
+    params.reverse()  # back to correct order
 
     if code_has_star_arg(code):
         if self.version > 3.0:
             star_arg = code.co_varnames[argc + kwonlyargcount]
             if annotate_dict and star_arg in annotate_dict:
-                params.append('*%s: %s' % (star_arg, annotate_dict[star_arg]))
+                params.append("*%s: %s" % (star_arg, annotate_dict[star_arg]))
             else:
-                params.append('*%s' % star_arg)
+                params.append("*%s" % star_arg)
         else:
-            params.append('*%s' % code.co_varnames[argc])
+            params.append("*%s" % code.co_varnames[argc])
         argc += 1
 
     # dump parameter list (with default values)
@@ -744,13 +792,15 @@ def make_function3(self, node, is_lambda, nested=1, code_node=None):
         # drop the (return) None since that was just put there
         # to have something to after the yield finishes.
         # FIXME: this is a bit hoaky and not general
-        if (len(ast) > 1 and
-            self.traverse(ast[-1]) == 'None' and
-            self.traverse(ast[-2]).strip().startswith('yield')):
+        if (
+            len(ast) > 1
+            and self.traverse(ast[-1]) == "None"
+            and self.traverse(ast[-2]).strip().startswith("yield")
+        ):
             del ast[-1]
             # Now pick out the expr part of the last statement
             ast_expr = ast[-1]
-            while ast_expr.kind != 'expr':
+            while ast_expr.kind != "expr":
                 ast_expr = ast_expr[0]
             ast[-1] = ast_expr
             pass
@@ -776,21 +826,21 @@ def make_function3(self, node, is_lambda, nested=1, code_node=None):
                 ends_in_comma = True
         else:
             if argc > 0:
-                self.write(', ')
+                self.write(", ")
                 ends_in_comma = True
 
         # FIXME: this is not correct for 3.5. or 3.6 (which works different)
         # and 3.7?
         if 3.0 <= self.version <= 3.2:
             kwargs = node[0]
-            last = len(kwargs)-1
+            last = len(kwargs) - 1
             i = 0
             for n in node[0]:
-                if n == 'kwarg':
-                    self.write('%s=' % n[0].attr)
+                if n == "kwarg":
+                    self.write("%s=" % n[0].attr)
                     self.preorder(n[1])
                     if i < last:
-                        self.write(', ')
+                        self.write(", ")
                         ends_in_comma = True
                         pass
                     else:
@@ -802,9 +852,11 @@ def make_function3(self, node, is_lambda, nested=1, code_node=None):
         elif self.version <= 3.5:
             # FIXME this is not qute right for 3.5
             for n in node:
-                if n == 'pos_arg':
+                if n == "pos_arg":
                     continue
-                elif self.version >= 3.4 and not (n.kind in ('kwargs', 'no_kwargs', 'kwarg')):
+                elif self.version >= 3.4 and not (
+                    n.kind in ("kwargs", "no_kwargs", "kwarg")
+                ):
                     continue
                 else:
                     self.preorder(n)
@@ -819,9 +871,9 @@ def make_function3(self, node, is_lambda, nested=1, code_node=None):
             free_tup = ann_dict = kw_dict = default_tup = None
             fn_bits = node[-1].attr
             index = -4  # Skip over:
-                        #  MAKE_FUNCTION,
-                        #  LOAD_CONST qualified name,
-                        #  LOAD_CONST code object
+            #  MAKE_FUNCTION,
+            #  LOAD_CONST qualified name,
+            #  LOAD_CONST code object
             if fn_bits[-1]:
                 free_tup = node[index]
                 index -= 1
@@ -834,18 +886,18 @@ def make_function3(self, node, is_lambda, nested=1, code_node=None):
             if fn_bits[-4]:
                 default_tup = node[index]
 
-            if kw_dict == 'expr':
+            if kw_dict == "expr":
                 kw_dict = kw_dict[0]
 
             # FIXME: handle free_tup, annotate_dict, and default_tup
             kw_args = [None] * kwonlyargcount
 
             if kw_dict:
-                assert kw_dict == 'dict'
-                defaults = [self.traverse(n, indent='') for n in kw_dict[:-2]]
+                assert kw_dict == "dict"
+                defaults = [self.traverse(n, indent="") for n in kw_dict[:-2]]
                 names = eval(self.traverse(kw_dict[-2]))
                 assert len(defaults) == len(names)
-                sep = ''
+                sep = ""
                 # FIXME: possibly handle line breaks
                 for i, n in enumerate(names):
                     idx = kwargs.index(n)
@@ -865,10 +917,10 @@ def make_function3(self, node, is_lambda, nested=1, code_node=None):
                     if flag:
                         n = kwargs[i]
                         if n in annotate_dict:
-                            kw_args[i] = "%s: %s" %(n, annotate_dict[n])
+                            kw_args[i] = "%s: %s" % (n, annotate_dict[n])
                         else:
                             kw_args[i] = "%s" % n
-            self.write(', '.join(kw_args))
+            self.write(", ".join(kw_args))
             ends_in_comma = False
 
         pass
@@ -878,41 +930,46 @@ def make_function3(self, node, is_lambda, nested=1, code_node=None):
 
     if code_has_star_star_arg(code):
         if not ends_in_comma:
-            self.write(', ')
+            self.write(", ")
         star_star_arg = code.co_varnames[argc + kwonlyargcount]
         if annotate_dict and star_star_arg in annotate_dict:
-            self.write('**%s: %s' % (star_star_arg, annotate_dict[star_star_arg]))
+            self.write("**%s: %s" % (star_star_arg, annotate_dict[star_star_arg]))
         else:
-            self.write('**%s' % star_star_arg)
+            self.write("**%s" % star_star_arg)
 
     if is_lambda:
         self.write(": ")
     else:
-        self.write(')')
-        if annotate_dict and 'return' in annotate_dict:
-            self.write(' -> %s' % annotate_dict['return'])
+        self.write(")")
+        if annotate_dict and "return" in annotate_dict:
+            self.write(" -> %s" % annotate_dict["return"])
         self.println(":")
 
-    if len(code.co_consts) > 0 and code.co_consts[0] is not None and not is_lambda: # ugly
+    if (
+        len(code.co_consts) > 0 and code.co_consts[0] is not None and not is_lambda
+    ):  # ugly
         # docstring exists, dump it
         print_docstring(self, self.indent, code.co_consts[0])
 
-    scanner_code._tokens = None # save memory
-    assert ast == 'stmts'
+    scanner_code._tokens = None  # save memory
+    assert ast == "stmts"
 
     all_globals = find_all_globals(ast, set())
-    globals, nonlocals = find_globals_and_nonlocals(ast, set(),
-                                                    set(), code, self.version)
+    globals, nonlocals = find_globals_and_nonlocals(
+        ast, set(), set(), code, self.version
+    )
 
     for g in sorted((all_globals & self.mod_globs) | globals):
-        self.println(self.indent, 'global ', g)
+        self.println(self.indent, "global ", g)
 
     for nl in sorted(nonlocals):
-        self.println(self.indent, 'nonlocal ', nl)
+        self.println(self.indent, "nonlocal ", nl)
 
     self.mod_globs -= all_globals
-    has_none = 'None' in code.co_names
+    has_none = "None" in code.co_names
     rn = has_none and not find_none(ast)
-    self.gen_source(ast, code.co_name, scanner_code._customize, is_lambda=is_lambda,
-                    returnNone=rn)
-    scanner_code._tokens = None; scanner_code._customize = None # save memory
+    self.gen_source(
+        ast, code.co_name, scanner_code._customize, is_lambda=is_lambda, returnNone=rn
+    )
+    scanner_code._tokens = None
+    scanner_code._customize = None  # save memory

--- a/uncompyle6/semantics/pysource.py
+++ b/uncompyle6/semantics/pysource.py
@@ -125,7 +125,7 @@ Python.
 #   evaluating the escape code.
 
 import sys
-IS_PYPY = '__pypy__' in sys.builtin_module_names
+IS_PYPY = "__pypy__" in sys.builtin_module_names
 PYTHON3 = (sys.version_info >= (3, 0))
 
 from xdis.code import iscode
@@ -144,6 +144,9 @@ from uncompyle6.semantics.check_ast import checker
 from uncompyle6.semantics.customize import customize_for_version
 from uncompyle6.semantics.helper import (
     print_docstring, find_globals_and_nonlocals, flatten_list)
+
+from uncompyle6.semantics.transform import TreeTransform
+
 from uncompyle6.scanners.tok import Token
 
 from uncompyle6.semantics.consts import (
@@ -164,10 +167,10 @@ else:
 
 def is_docstring(node):
     try:
-        return (node[0][0].kind == 'assign' and
-            node[0][0][1][0].pattr == '__doc__')
+        return node[0][0].kind == "assign" and node[0][0][1][0].pattr == "__doc__"
     except:
         return False
+
 
 class SourceWalkerError(Exception):
     def __init__(self, errmsg):
@@ -176,13 +179,22 @@ class SourceWalkerError(Exception):
     def __str__(self):
         return self.errmsg
 
-class SourceWalker(GenericASTTraversal, object):
-    stacked_params = ('f', 'indent', 'is_lambda', '_globals')
 
-    def __init__(self, version, out, scanner, showast=False,
-                 debug_parser=PARSER_DEFAULT_DEBUG,
-                 compile_mode='exec', is_pypy=IS_PYPY,
-                 linestarts={}, tolerate_errors=False):
+class SourceWalker(GenericASTTraversal, object):
+    stacked_params = ("f", "indent", "is_lambda", "_globals")
+
+    def __init__(
+        self,
+        version,
+        out,
+        scanner,
+        showast=False,
+        debug_parser=PARSER_DEFAULT_DEBUG,
+        compile_mode="exec",
+        is_pypy=IS_PYPY,
+        linestarts={},
+        tolerate_errors=False,
+    ):
         """`version' is the Python version (a float) of the Python dialect
         of both the syntax tree and language we should produce.
 
@@ -207,14 +219,18 @@ class SourceWalker(GenericASTTraversal, object):
 
         """
         GenericASTTraversal.__init__(self, ast=None)
+
         self.scanner = scanner
-        params = {
-            'f': out,
-            'indent': '',
-            }
+        params = {"f": out, "indent": ""}
         self.version = version
-        self.p = get_python_parser(version, debug_parser=dict(debug_parser),
-                                   compile_mode=compile_mode, is_pypy=is_pypy)
+        self.p = get_python_parser(
+            version,
+            debug_parser=dict(debug_parser),
+            compile_mode=compile_mode,
+            is_pypy=is_pypy,
+        )
+
+        self.treeTransform = TreeTransform(showast)
         self.debug_parser = dict(debug_parser)
         self.showast = showast
         self.params = params
@@ -253,10 +269,21 @@ class SourceWalker(GenericASTTraversal, object):
 
         return
 
+    def maybe_show_tree(self, ast):
+        if self.showast and self.treeTransform.showast:
+            self.println("""
+---- end before transform
+---- begin after transform
+""" + "    "
+            )
+
+        if isinstance(self.showast, dict) and self.showast.get:
+            maybe_show_tree(self, ast)
+
     def str_with_template(self, ast):
         stream = sys.stdout
-        stream.write(self.str_with_template1(ast, '', None))
-        stream.write('\n')
+        stream.write(self.str_with_template1(ast, "", None))
+        stream.write("\n")
 
     def str_with_template1(self, ast, indent, sibNum=None):
         rv = str(ast.kind)
@@ -275,20 +302,28 @@ class SourceWalker(GenericASTTraversal, object):
             key = key[i]
             pass
 
+        if ast.transformed_by is not None:
+            if ast.transformed_by is True:
+                rv += " transformed"
+            else:
+                rv += " transformed by %s" % ast.transformed_by
+                pass
+            pass
         if key.kind in table:
             rv += ": %s" % str(table[key.kind])
 
         rv = indent + rv
-        indent += '    '
+        indent += "    "
         i = 0
         for node in ast:
-            if hasattr(node, '__repr1__'):
+
+            if hasattr(node, "__repr1__"):
                 if enumerate_children:
-                    child =  self.str_with_template1(node, indent, i)
+                    child = self.str_with_template1(node, indent, i)
                 else:
                     child = self.str_with_template1(node, indent, None)
             else:
-                inst = node.format(line_prefix='L.')
+                inst = node.format(line_prefix="L.")
                 if inst.startswith("\n"):
                     # Nuke leading \n
                     inst = inst[1:]
@@ -301,34 +336,41 @@ class SourceWalker(GenericASTTraversal, object):
             i += 1
         return rv
 
-
     def indent_if_source_nl(self, line_number, indent):
-        if (line_number != self.line_number):
+        if line_number != self.line_number:
             self.write("\n" + self.indent + INDENT_PER_LEVEL[:-1])
         return self.line_number
 
-    f = property(lambda s: s.params['f'],
-                 lambda s, x: s.params.__setitem__('f', x),
-                 lambda s: s.params.__delitem__('f'),
-                 None)
+    f = property(
+        lambda s: s.params["f"],
+        lambda s, x: s.params.__setitem__("f", x),
+        lambda s: s.params.__delitem__("f"),
+        None,
+    )
 
-    indent = property(lambda s: s.params['indent'],
-                      lambda s, x: s.params.__setitem__('indent', x),
-                      lambda s: s.params.__delitem__('indent'),
-                      None)
+    indent = property(
+        lambda s: s.params["indent"],
+        lambda s, x: s.params.__setitem__("indent", x),
+        lambda s: s.params.__delitem__("indent"),
+        None,
+    )
 
-    is_lambda = property(lambda s: s.params['is_lambda'],
-                         lambda s, x: s.params.__setitem__('is_lambda', x),
-                         lambda s: s.params.__delitem__('is_lambda'),
-                         None)
+    is_lambda = property(
+        lambda s: s.params["is_lambda"],
+        lambda s, x: s.params.__setitem__("is_lambda", x),
+        lambda s: s.params.__delitem__("is_lambda"),
+        None,
+    )
 
-    _globals = property(lambda s: s.params['_globals'],
-                        lambda s, x: s.params.__setitem__('_globals', x),
-                        lambda s: s.params.__delitem__('_globals'),
-                        None)
+    _globals = property(
+        lambda s: s.params["_globals"],
+        lambda s, x: s.params.__setitem__("_globals", x),
+        lambda s: s.params.__delitem__("_globals"),
+        None,
+    )
 
     def set_pos_info(self, node):
-        if hasattr(node, 'linestart') and node.linestart:
+        if hasattr(node, "linestart") and node.linestart:
             self.line_number = node.linestart
 
     def preorder(self, node=None):
@@ -339,29 +381,30 @@ class SourceWalker(GenericASTTraversal, object):
         self.indent += indent
 
     def indent_less(self, indent=TAB):
-        self.indent = self.indent[:-len(indent)]
+        self.indent = self.indent[: -len(indent)]
 
     def traverse(self, node, indent=None, is_lambda=False):
         self.param_stack.append(self.params)
-        if indent is None: indent = self.indent
+        if indent is None:
+            indent = self.indent
         p = self.pending_newlines
         self.pending_newlines = 0
         self.params = {
-            '_globals': {},
-            '_nonlocals': {},   # Python 3 has nonlocal
-            'f': StringIO(),
-            'indent': indent,
-            'is_lambda': is_lambda,
-            }
+            "_globals": {},
+            "_nonlocals": {},  # Python 3 has nonlocal
+            "f": StringIO(),
+            "indent": indent,
+            "is_lambda": is_lambda,
+        }
         self.preorder(node)
-        self.f.write('\n'*self.pending_newlines)
+        self.f.write("\n" * self.pending_newlines)
         result = self.f.getvalue()
         self.params = self.param_stack.pop()
         self.pending_newlines = p
         return result
 
     def write(self, *data):
-        if (len(data) == 0) or (len(data) == 1 and data[0] == ''):
+        if (len(data) == 0) or (len(data) == 1 and data[0] == ""):
             return
         if not PYTHON3:
             out = ''.join((unicode(j) for j in data))
@@ -369,7 +412,7 @@ class SourceWalker(GenericASTTraversal, object):
             out = ''.join((str(j) for j in data))
         n = 0
         for i in out:
-            if i == '\n':
+            if i == "\n":
                 n += 1
                 if n == len(out):
                     self.pending_newlines = max(self.pending_newlines, n)
@@ -382,11 +425,11 @@ class SourceWalker(GenericASTTraversal, object):
                 break
 
         if self.pending_newlines > 0:
-            self.f.write('\n'*self.pending_newlines)
+            self.f.write("\n" * self.pending_newlines)
             self.pending_newlines = 0
 
         for i in out[::-1]:
-            if i == '\n':
+            if i == "\n":
                 self.pending_newlines += 1
             else:
                 break
@@ -399,106 +442,106 @@ class SourceWalker(GenericASTTraversal, object):
         self.f.write(out)
 
     def println(self, *data):
-        if data and not(len(data) == 1 and data[0] == ''):
+        if data and not (len(data) == 1 and data[0] == ""):
             self.write(*data)
         self.pending_newlines = max(self.pending_newlines, 1)
 
     def is_return_none(self, node):
         # Is there a better way?
-        ret = (node[0] == 'ret_expr'
-               and node[0][0] == 'expr'
-               and node[0][0][0] == 'LOAD_CONST'
-               and node[0][0][0].pattr is None)
-        if self.version <= 2.6:
-            return ret
-        else:
-            # FIXME: should the SyntaxTree expression be folded into
-            # the global RETURN_NONE constant?
-            return (ret or
-                    node == SyntaxTree('return',
-                                [SyntaxTree('ret_expr', [NONE]), Token('RETURN_VALUE')]))
+        ret = (
+            node[0] == "ret_expr"
+            and node[0][0] == "expr"
+            and node[0][0][0] == "LOAD_CONST"
+            and node[0][0][0].pattr is None
+        )
+
+        # FIXME: should the SyntaxTree expression be folded into
+        # the global RETURN_NONE constant?
+        return ret or node == SyntaxTree(
+            "return", [SyntaxTree("ret_expr", [NONE]), Token("RETURN_VALUE")]
+        )
 
     # Python 3.x can have be dead code as a result of its optimization?
     # So we'll add a # at the end of the return lambda so the rest is ignored
     def n_return_lambda(self, node):
         if 1 <= len(node) <= 2:
             self.preorder(node[0])
-            self.write(' # Avoid dead code: ')
+            self.write(" # Avoid dead code: ")
             self.prune()
         else:
             # We can't comment out like above because there may be a trailing ')'
             # that needs to be written
-            assert len(node) == 3 and node[2] == 'LAMBDA_MARKER'
+            assert len(node) == 3 and node[2] == "LAMBDA_MARKER"
             self.preorder(node[0])
             self.prune()
 
     def n_return(self, node):
-        if self.params['is_lambda']:
+        if self.params["is_lambda"]:
             self.preorder(node[0])
             self.prune()
         else:
-            self.write(self.indent, 'return')
+            self.write(self.indent, "return")
             # One reason we worry over whether we use "return None" or "return"
             # is that inside a generator, "return None" is illegal.
             # Thank you, Python!
-            if (self.return_none or not self.is_return_none(node)):
-                self.write(' ')
+            if self.return_none or not self.is_return_none(node):
+                self.write(" ")
                 self.preorder(node[0])
             self.println()
-            self.prune() # stop recursing
+            self.prune()  # stop recursing
 
     def n_return_if_stmt(self, node):
-        if self.params['is_lambda']:
-            self.write(' return ')
+        if self.params["is_lambda"]:
+            self.write(" return ")
             self.preorder(node[0])
             self.prune()
         else:
-            self.write(self.indent, 'return')
+            self.write(self.indent, "return")
             if self.return_none or not self.is_return_none(node):
-                self.write(' ')
+                self.write(" ")
                 self.preorder(node[0])
             self.println()
-            self.prune() # stop recursing
+            self.prune()  # stop recursing
 
     def n_yield(self, node):
-        if node != SyntaxTree('yield', [NONE, Token('YIELD_VALUE')]):
-            self.template_engine(( 'yield %c', 0), node)
+        if node != SyntaxTree("yield", [NONE, Token("YIELD_VALUE")]):
+            self.template_engine(("yield %c", 0), node)
         elif self.version <= 2.4:
             # Early versions of Python don't allow a plain "yield"
-            self.write('yield None')
+            self.write("yield None")
         else:
-            self.write('yield')
+            self.write("yield")
 
-        self.prune() # stop recursing
+        self.prune()  # stop recursing
 
     def n_build_slice3(self, node):
         p = self.prec
         self.prec = 100
         if not node[0].isNone():
             self.preorder(node[0])
-        self.write(':')
+        self.write(":")
         if not node[1].isNone():
             self.preorder(node[1])
-        self.write(':')
+        self.write(":")
         if not node[2].isNone():
             self.preorder(node[2])
         self.prec = p
-        self.prune() # stop recursing
+        self.prune()  # stop recursing
 
     def n_build_slice2(self, node):
         p = self.prec
         self.prec = 100
         if not node[0].isNone():
             self.preorder(node[0])
-        self.write(':')
+        self.write(":")
         if not node[1].isNone():
             self.preorder(node[1])
         self.prec = p
-        self.prune() # stop recursing
+        self.prune()  # stop recursing
 
     def n_expr(self, node):
         p = self.prec
-        if node[0].kind.startswith('binary_expr'):
+        if node[0].kind.startswith("binary_expr"):
             n = node[0][-1][0]
         else:
             n = node[0]
@@ -508,20 +551,20 @@ class SourceWalker(GenericASTTraversal, object):
         #     self.source_linemap[self.current_line_number] = n.linestart
 
         self.prec = PRECEDENCE.get(n.kind, -2)
-        if n == 'LOAD_CONST' and repr(n.pattr)[0] == '-':
+        if n == "LOAD_CONST" and repr(n.pattr)[0] == "-":
             self.prec = 6
 
         if p < self.prec:
-            self.write('(')
+            self.write("(")
             self.preorder(node[0])
-            self.write(')')
+            self.write(")")
         else:
             self.preorder(node[0])
         self.prec = p
         self.prune()
 
     def n_ret_expr(self, node):
-        if len(node) == 1 and node[0] == 'expr':
+        if len(node) == 1 and node[0] == "expr":
             self.n_expr(node[0])
         else:
             self.n_expr(node)
@@ -530,9 +573,9 @@ class SourceWalker(GenericASTTraversal, object):
 
     def n_binary_expr(self, node):
         self.preorder(node[0])
-        self.write(' ')
+        self.write(" ")
         self.preorder(node[-1])
-        self.write(' ')
+        self.write(" ")
         self.prec -= 1
         self.preorder(node[1])
         self.prec += 1
@@ -545,32 +588,35 @@ class SourceWalker(GenericASTTraversal, object):
     def pp_tuple(self, tup):
         """Pretty print a tuple"""
         last_line = self.f.getvalue().split("\n")[-1]
-        l = len(last_line)+1
-        indent = ' ' * l
-        self.write('(')
-        sep = ''
+        l = len(last_line) + 1
+        indent = " " * l
+        self.write("(")
+        sep = ""
         for item in tup:
             self.write(sep)
             l += len(sep)
             s = repr(item)
             l += len(s)
             self.write(s)
-            sep = ','
+            sep = ","
             if l > LINE_LENGTH:
                 l = 0
-                sep += '\n' + indent
+                sep += "\n" + indent
             else:
-                sep += ' '
+                sep += " "
                 pass
             pass
         if len(tup) == 1:
             self.write(", ")
-        self.write(')')
+        self.write(")")
 
     def n_LOAD_CONST(self, node):
         attr = node.attr
-        data = node.pattr; datatype = type(data)
-        if isinstance(data, float) and str(data) in frozenset(['nan', '-nan', 'inf', '-inf']):
+        data = node.pattr
+        datatype = type(data)
+        if isinstance(data, float) and str(data) in frozenset(
+            ["nan", "-nan", "inf", "-inf"]
+        ):
             # float values 'nan' and 'inf' are not directly representable in Python at least
             # before 3.5 and even there it is via a library constant.
             # So we will canonicalize their representation as float('nan') and float('inf')
@@ -580,14 +626,14 @@ class SourceWalker(GenericASTTraversal, object):
             # would result in 'LOAD_CONST; UNARY_NEGATIVE'
             # change:hG/2002-02-07: this was done for all negative integers
             # todo: check whether this is necessary in Python 2.1
-            self.write( hex(data) )
+            self.write(hex(data))
         elif datatype is type(Ellipsis):
-            self.write('...')
+            self.write("...")
         elif attr is None:
             # LOAD_CONST 'None' only occurs, when None is
             # implicit eg. in 'return' w/o params
             # pass
-            self.write('None')
+            self.write("None")
         elif isinstance(data, tuple):
             self.pp_tuple(data)
         elif isinstance(attr, bool):
@@ -620,9 +666,11 @@ class SourceWalker(GenericASTTraversal, object):
         self.prune()
 
     def n_delete_subscript(self, node):
-        if node[-2][0] == 'build_list' and node[-2][0][-1].kind.startswith('BUILD_TUPLE'):
-            if node[-2][0][-1] != 'BUILD_TUPLE_0':
-                node[-2][0].kind = 'build_tuple2'
+        if node[-2][0] == "build_list" and node[-2][0][-1].kind.startswith(
+            "BUILD_TUPLE"
+        ):
+            if node[-2][0][-1] != "BUILD_TUPLE_0":
+                node[-2][0].kind = "build_tuple2"
         self.default(node)
 
     n_store_subscript = n_subscript = n_delete_subscript
@@ -636,103 +684,78 @@ class SourceWalker(GenericASTTraversal, object):
         exec_stmt ::= expr exprlist DUP_TOP EXEC_STMT
         exec_stmt ::= expr exprlist EXEC_STMT
         """
-        self.write(self.indent, 'exec ')
+        self.write(self.indent, "exec ")
         self.preorder(node[0])
         if not node[1][0].isNone():
-            sep = ' in '
+            sep = " in "
             for subnode in node[1]:
-                self.write(sep); sep = ", "
+                self.write(sep)
+                sep = ", "
                 self.preorder(subnode)
         self.println()
-        self.prune() # stop recursing
-
-    def n_ifelsestmt(self, node, preprocess=False):
-        else_suite = node[3]
-
-        n = else_suite[0]
-
-        if len(n) == 1 == len(n[0]) and n[0] == '_stmts':
-            n = n[0][0][0]
-        elif n[0].kind in ('lastc_stmt', 'lastl_stmt'):
-            n = n[0][0]
-        else:
-            if not preprocess:
-                self.default(node)
-            return
-
-        if n.kind in ('ifstmt', 'iflaststmt', 'iflaststmtl'):
-            node.kind = 'ifelifstmt'
-            n.kind = 'elifstmt'
-        elif n.kind in ('ifelsestmtr',):
-            node.kind = 'ifelifstmt'
-            n.kind = 'elifelsestmtr'
-        elif n.kind in ('ifelsestmt', 'ifelsestmtc', 'ifelsestmtl'):
-            node.kind = 'ifelifstmt'
-            self.n_ifelsestmt(n, preprocess=True)
-            if n == 'ifelifstmt':
-                n.kind = 'elifelifstmt'
-            elif n.kind in ('ifelsestmt', 'ifelsestmtc', 'ifelsestmtl'):
-                n.kind = 'elifelsestmt'
-        if not preprocess:
-            self.default(node)
-
-    n_ifelsestmtc = n_ifelsestmtl = n_ifelsestmt
+        self.prune()  # stop recursing
 
     def n_ifelsestmtr(self, node):
-        if node[2] == 'COME_FROM':
+        if node[2] == "COME_FROM":
             return_stmts_node = node[3]
-            node.kind = 'ifelsestmtr2'
+            node.kind = "ifelsestmtr2"
         else:
             return_stmts_node = node[2]
         if len(return_stmts_node) != 2:
             self.default(node)
 
-        if (not (return_stmts_node[0][0][0] == 'ifstmt'
-                 and return_stmts_node[0][0][0][1][0] == 'return_if_stmts')
-            and not (return_stmts_node[0][-1][0] == 'ifstmt'
-                     and return_stmts_node[0][-1][0][1][0] == 'return_if_stmts')):
+        if not (
+            return_stmts_node[0][0][0] == "ifstmt"
+            and return_stmts_node[0][0][0][1][0] == "return_if_stmts"
+        ) and not (
+            return_stmts_node[0][-1][0] == "ifstmt"
+            and return_stmts_node[0][-1][0][1][0] == "return_if_stmts"
+        ):
             self.default(node)
             return
 
-        self.write(self.indent, 'if ')
+        self.write(self.indent, "if ")
         self.preorder(node[0])
-        self.println(':')
+        self.println(":")
         self.indent_more()
         self.preorder(node[1])
         self.indent_less()
 
         if_ret_at_end = False
         if len(return_stmts_node[0]) >= 3:
-            if (return_stmts_node[0][-1][0] == 'ifstmt'
-                and return_stmts_node[0][-1][0][1][0] == 'return_if_stmts'):
+            if (
+                return_stmts_node[0][-1][0] == "ifstmt"
+                and return_stmts_node[0][-1][0][1][0] == "return_if_stmts"
+            ):
                 if_ret_at_end = True
 
         past_else = False
         prev_stmt_is_if_ret = True
         for n in return_stmts_node[0]:
-            if (n[0] == 'ifstmt' and n[0][1][0] == 'return_if_stmts'):
+            if n[0] == "ifstmt" and n[0][1][0] == "return_if_stmts":
                 if prev_stmt_is_if_ret:
-                    n[0].kind = 'elifstmt'
+                    n[0].kind = "elifstmt"
                 prev_stmt_is_if_ret = True
             else:
                 prev_stmt_is_if_ret = False
                 if not past_else and not if_ret_at_end:
-                    self.println(self.indent, 'else:')
+                    self.println(self.indent, "else:")
                     self.indent_more()
                     past_else = True
             self.preorder(n)
         if not past_else or if_ret_at_end:
-            self.println(self.indent, 'else:')
+            self.println(self.indent, "else:")
             self.indent_more()
         self.preorder(return_stmts_node[1])
         self.indent_less()
         self.prune()
+
     n_ifelsestmtr2 = n_ifelsestmtr
 
     def n_elifelsestmtr(self, node):
-        if node[2] == 'COME_FROM':
+        if node[2] == "COME_FROM":
             return_stmts_node = node[3]
-            node.kind = 'elifelsestmtr2'
+            node.kind = "elifelsestmtr2"
         else:
             return_stmts_node = node[2]
 
@@ -740,21 +763,21 @@ class SourceWalker(GenericASTTraversal, object):
             self.default(node)
 
         for n in return_stmts_node[0]:
-            if not (n[0] == 'ifstmt' and n[0][1][0] == 'return_if_stmts'):
+            if not (n[0] == "ifstmt" and n[0][1][0] == "return_if_stmts"):
                 self.default(node)
                 return
 
-        self.write(self.indent, 'elif ')
+        self.write(self.indent, "elif ")
         self.preorder(node[0])
-        self.println(':')
+        self.println(":")
         self.indent_more()
         self.preorder(node[1])
         self.indent_less()
 
         for n in return_stmts_node[0]:
-            n[0].kind = 'elifstmt'
+            n[0].kind = "elifstmt"
             self.preorder(n)
-        self.println(self.indent, 'else:')
+        self.println(self.indent, "else:")
         self.indent_more()
         self.preorder(return_stmts_node[1])
         self.indent_less()
@@ -764,32 +787,30 @@ class SourceWalker(GenericASTTraversal, object):
         if self.version <= 2.1:
             if len(node) == 2:
                 store = node[1]
-                assert store == 'store'
+                assert store == "store"
                 if store[0].pattr == node[0].pattr:
                     self.write("import %s\n" % node[0].pattr)
                 else:
-                    self.write("import %s as %s\n" %
-                               (node[0].pattr, store[0].pattr))
+                    self.write("import %s as %s\n" % (node[0].pattr, store[0].pattr))
                     pass
                 pass
-            self.prune() # stop recursing
-
+            self.prune()  # stop recursing
 
         store_node = node[-1][-1]
-        assert store_node.kind.startswith('STORE_')
+        assert store_node.kind.startswith("STORE_")
         iname = node[0].pattr  # import name
-        sname = store_node.pattr # store_name
-        if iname and iname == sname or iname.startswith(sname + '.'):
+        sname = store_node.pattr  # store_name
+        if iname and iname == sname or iname.startswith(sname + "."):
             self.write(iname)
         else:
-            self.write(iname, ' as ', sname)
-        self.prune() # stop recursing
+            self.write(iname, " as ", sname)
+        self.prune()  # stop recursing
 
     def n_import_from(self, node):
         relative_path_index = 0
         if self.version >= 2.5:
             if node[relative_path_index].pattr > 0:
-                node[2].pattr = ('.' * node[relative_path_index].pattr) + node[2].pattr
+                node[2].pattr = ("." * node[relative_path_index].pattr) + node[2].pattr
             if self.version > 2.7:
                 if isinstance(node[1].pattr, tuple):
                     imports = node[1].pattr
@@ -804,17 +825,22 @@ class SourceWalker(GenericASTTraversal, object):
 
     def n_mkfunc(self, node):
 
-        if self.version >= 3.3 or node[-2] in ('kwargs', 'no_kwargs'):
+        if self.version >= 3.3 or node[-2] in ("kwargs", "no_kwargs"):
             # LOAD_CONST code object ..
-            # LOAD_CONST        'x0'  if >= 3.3
+            # LOAD_CONST        "x0"  if >= 3.3
             # MAKE_FUNCTION ..
             code_node = node[-3]
-        elif node[-2] == 'expr':
+        elif node[-2] == "expr":
             code_node = node[-2][0]
         else:
             # LOAD_CONST code object ..
             # MAKE_FUNCTION ..
             code_node = node[-2]
+
+        if not iscode(code_node.attr):
+            # docstring exists
+            code_node = node[-4]
+        assert iscode(code_node.attr)
 
         func_name = code_node.attr.co_name
         self.write(func_name)
@@ -824,9 +850,9 @@ class SourceWalker(GenericASTTraversal, object):
         self.make_function(node, is_lambda=False, code_node=code_node)
 
         if len(self.param_stack) > 1:
-            self.write('\n\n')
+            self.write("\n\n")
         else:
-            self.write('\n\n\n')
+            self.write("\n\n\n")
         self.indent_less()
         self.prune() # stop recursing
 
@@ -836,6 +862,75 @@ class SourceWalker(GenericASTTraversal, object):
             make_function3(self, node, is_lambda, nested, code_node)
         else:
             make_function2(self, node, is_lambda, nested, code_node)
+
+    def n_docstring(self, node):
+
+        indent = self.indent
+        docstring = node[0].pattr
+
+        quote = '"""'
+        if docstring.find(quote) >= 0:
+            if docstring.find("'''") == -1:
+                quote = "'''"
+
+        self.write(indent)
+        docstring = repr(docstring.expandtabs())[1:-1]
+
+        for (orig, replace) in (('\\\\', '\t'),
+                                ('\\r\\n', '\n'),
+                                ('\\n', '\n'),
+                                ('\\r', '\n'),
+                                ('\\"', '"'),
+                                ("\\'", "'")):
+            docstring = docstring.replace(orig, replace)
+
+        # Do a raw string if there are backslashes but no other escaped characters:
+        # also check some edge cases
+        if ('\t' in docstring
+            and '\\' not in docstring
+            and len(docstring) >= 2
+            and docstring[-1] != '\t'
+            and (docstring[-1] != '"'
+                or docstring[-2] == '\t')):
+            self.write('r') # raw string
+            # Restore backslashes unescaped since raw
+            docstring = docstring.replace('\t', '\\')
+        else:
+            # Escape the last character if it is the same as the
+            # triple quote character.
+            quote1 = quote[-1]
+            if len(docstring) and docstring[-1] == quote1:
+                docstring = docstring[:-1] + '\\' + quote1
+
+            # Escape triple quote when needed
+            if quote == '"""':
+                replace_str = '\\"""'
+            else:
+                assert quote == "'''"
+                replace_str = "\\'''"
+
+            docstring = docstring.replace(quote, replace_str)
+            docstring = docstring.replace('\t', '\\\\')
+
+        lines = docstring.split('\n')
+
+        self.write(quote)
+        if len(lines) == 0:
+            self.println(quote)
+        elif len(lines) == 1:
+            self.println(lines[0], quote)
+        else:
+            self.println(lines[0])
+            for line in lines[1:-1]:
+                if line:
+                    self.println( line )
+                else:
+                    self.println( "\n\n" )
+                    pass
+                pass
+            self.println(lines[-1], quote)
+        self.prune()
+
 
     def n_mklambda(self, node):
         self.make_function(node, is_lambda=True, code_node=node[-2])
@@ -863,40 +958,43 @@ class SourceWalker(GenericASTTraversal, object):
         # FIXME: DRY with other use
         while n == 'list_iter':
             n = n[0]  # iterate one nesting deeper
-            if   n == 'list_for':	n = n[3]
-            elif n == 'list_if':	n = n[2]
-            elif n == 'list_if_not': n = n[2]
-        assert n == 'lc_body'
-        self.write( '[ ')
+            if n == "list_for":
+                n = n[3]
+            elif n == "list_if":
+                n = n[2]
+            elif n == "list_if_not":
+                n = n[2]
+        assert n == "lc_body"
+        self.write("[ ")
 
         if self.version >= 2.7:
             expr = n[0]
             list_iter = node[-1]
         else:
             expr = n[1]
-            if node[-2] == 'JUMP_BACK':
+            if node[-2] == "JUMP_BACK":
                 list_iter = node[-3]
             else:
                 list_iter = node[-2]
 
-        assert expr == 'expr'
-        assert list_iter == 'list_iter'
+        assert expr == "expr"
+        assert list_iter == "list_iter"
 
         # FIXME: use source line numbers for directing line breaks
 
         line_number = self.line_number
         last_line = self.f.getvalue().split("\n")[-1]
         l = len(last_line)
-        indent = ' ' * (l-1)
+        indent = " " * (l - 1)
 
         self.preorder(expr)
         line_number = self.indent_if_source_nl(line_number, indent)
         self.preorder(list_iter)
         l2 = self.indent_if_source_nl(line_number, indent)
         if l2 != line_number:
-            self.write(' ' * (len(indent) - len(self.indent) - 1) + ']')
+            self.write(" " * (len(indent) - len(self.indent) - 1) + "]")
         else:
-            self.write( ' ]')
+            self.write(" ]")
         self.prec = p
         self.prune() # stop recursing
 
@@ -956,23 +1054,23 @@ class SourceWalker(GenericASTTraversal, object):
         elif self.version <= 2.7 and node == 'generator_exp':
             if node[0] == 'LOAD_GENEXPR':
                 cn = node[0]
-            elif node[0] == 'load_closure':
+            elif node[0] == "load_closure":
                 cn = node[1]
 
-        elif self.version >= 3.0 and node == 'generator_exp':
-            if node[0] == 'load_genexpr':
+        elif self.version >= 3.0 and node == "generator_exp":
+            if node[0] == "load_genexpr":
                 load_genexpr = node[0]
-            elif node[1] == 'load_genexpr':
+            elif node[1] == "load_genexpr":
                 load_genexpr = node[1]
             cn = load_genexpr[0]
-        elif hasattr(node[code_index], 'attr'):
+        elif hasattr(node[code_index], "attr"):
             # Python 2.5+ (and earlier?) does this
             cn = node[code_index]
         else:
-            if len(node[1]) > 1 and hasattr(node[1][1], 'attr'):
+            if len(node[1]) > 1 and hasattr(node[1][1], "attr"):
                 # Python 3.3+ does this
                 cn = node[1][1]
-            elif hasattr(node[1][0], 'attr'):
+            elif hasattr(node[1][0], "attr"):
                 # Python 3.2 does this
                 cn = node[1][0]
             else:
@@ -986,57 +1084,55 @@ class SourceWalker(GenericASTTraversal, object):
         ast = ast[0][0][0]
 
         n = ast[iter_index]
-        assert n == 'comp_iter', n
+        assert n == "comp_iter", n
 
         # Find the comprehension body. It is the inner-most
         # node that is not list_.. .
-        while n == 'comp_iter': # list_iter
-            n = n[0] # recurse one step
-            if n == 'comp_for':
-                if n[0] == 'SETUP_LOOP':
+        while n == "comp_iter":  # list_iter
+            n = n[0]  # recurse one step
+            if n == "comp_for":
+                if n[0] == "SETUP_LOOP":
                     n = n[4]
                 else:
                     n = n[3]
-            elif n == 'comp_if':
+            elif n == "comp_if":
                 n = n[2]
-            elif n == 'comp_if_not':
+            elif n == "comp_if_not":
                 n = n[2]
 
-        assert n == 'comp_body', n
+        assert n == "comp_body", n
 
         self.preorder(n[0])
-        self.write(' for ')
-        self.preorder(ast[iter_index-1])
-        self.write(' in ')
-        if node[2] == 'expr':
+        self.write(" for ")
+        self.preorder(ast[iter_index - 1])
+        self.write(" in ")
+        if node[2] == "expr":
             iter_expr = node[2]
         else:
             iter_expr = node[-3]
-        assert iter_expr == 'expr'
+        assert iter_expr == "expr"
         self.preorder(iter_expr)
         self.preorder(ast[iter_index])
         self.prec = p
 
     def n_generator_exp(self, node):
-        self.write('(')
-        if self.version > 3.2:
-            code_index = -6
-        else:
-            code_index = -5
+        self.write("(")
+        code_index = -6
         self.comprehension_walk(node, iter_index=3, code_index=code_index)
-        self.write(')')
+        self.write(")")
         self.prune()
 
     def n_set_comp(self, node):
-        self.write('{')
-        if node[0] in ['LOAD_SETCOMP', 'LOAD_DICTCOMP']:
+        self.write("{")
+        if node[0] in ["LOAD_SETCOMP", "LOAD_DICTCOMP"]:
             self.comprehension_walk_newer(node, 1, 0)
-        elif node[0].kind == 'load_closure' and self.version >= 3.0:
+        elif node[0].kind == "load_closure":
             self.setcomprehension_walk3(node, collection_index=4)
         else:
             self.comprehension_walk(node, iter_index=4)
-        self.write('}')
+        self.write("}")
         self.prune()
+
     n_dict_comp = n_set_comp
 
     def comprehension_walk_newer(self, node, iter_index, code_index=-5):
@@ -1055,9 +1151,9 @@ class SourceWalker(GenericASTTraversal, object):
 
         # skip over: sstmt, stmt, return, ret_expr
         # and other singleton derivations
-        while (len(ast) == 1
-               or (ast in ('sstmt', 'return')
-                   and ast[-1] in ('RETURN_LAST', 'RETURN_VALUE'))):
+        while len(ast) == 1 or (
+            ast in ("sstmt", "return") and ast[-1] in ("RETURN_LAST", "RETURN_VALUE")
+        ):
             self.prec = 100
             ast = ast[0]
 
@@ -2087,6 +2183,11 @@ class SourceWalker(GenericASTTraversal, object):
         ast = self.build_ast(code._tokens, code._customize)
         code._tokens = None # save memory
         assert ast == 'stmts'
+
+
+        if ast[0] == "docstring":
+            self.println(self.traverse(ast[0]))
+            del ast[0]
 
         first_stmt = ast[0][0]
         if 3.0 <= self.version <= 3.3:


### PR DESCRIPTION
Adds a tree-transformation phase where we can simplify the AST such as turning an 
`if ... raise` into an `assert`  and `if ..  else if ..`  into `if .. elif ... `. 

See corresponding branch in decompyle3. 
