### PR TITLE
parsers: parse2: fix: also emit expr32 if count perfectly divisible by 1024

### DIFF
--- a/uncompyle6/parsers/parse2.py
+++ b/uncompyle6/parsers/parse2.py
@@ -319,7 +319,7 @@ class Python2Parser(PythonParser):
                 build_count = token.attr
                 thousands = build_count // 1024
                 thirty32s = (build_count // 32) % 32
-                if thirty32s > 0:
+                if thirty32s > 0 or thousands > 0:
                     rule = "expr32 ::=%s" % (" expr" * 32)
                     self.add_unique_rule(rule, opname_base, build_count, customize)
                 if thousands > 0:

--- a/uncompyle6/parsers/parse3.py
+++ b/uncompyle6/parsers/parse3.py
@@ -844,7 +844,7 @@ class Python3Parser(PythonParser):
                     build_count = token.attr
                     thousands = build_count // 1024
                     thirty32s = (build_count // 32) % 32
-                    if thirty32s > 0:
+                    if thirty32s > 0 or thousands > 0:
                         rule = "expr32 ::=%s" % (" expr" * 32)
                         self.add_unique_rule(rule, opname_base, build_count, customize)
                         pass


### PR DESCRIPTION
`expr1024` requires `expr32`, but a `build_count` of 1024 would emit only the
`expr1024` rule and rely on luck of it being emitted somewhere else.

Emit `expr32` rule either if there is a `expr32` use or a `expr1024` use to avoid.