### PR TITLE
docs: fix simple typo, unecessary -> unnecessary

### DIFF
--- a/test/simple_source/looping/12_if_while_true_pass.py
+++ b/test/simple_source/looping/12_if_while_true_pass.py
@@ -1,5 +1,5 @@
 # Python 3.3 pyclbr.py
-# Note that Python 3 adds a lot of unecessary "continues"
+# Note that Python 3 adds a lot of unnecessary "continues"
 # and puts that in for "pass"
 def _readmodule(g, token, path):
     for tokentype in g:


### PR DESCRIPTION
There is a small typo in test/simple_source/looping/12_if_while_true_pass.py.

Should read `unnecessary` rather than `unecessary`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md