### PR TITLE
'NoneType' object is not iterable with numproc > 1

### DIFF
--- a/uncompyle6/bin/uncompile.py
+++ b/uncompyle6/bin/uncompile.py
@@ -225,7 +225,7 @@ def main_bin():
                     if f is None:
                         break
                     (t, o, f, v) = \
-                      main(src_base, out_base, [f], None, outfile, **options)
+                      main(src_base, out_base, [f], [], outfile, **options)
                     tot_files += t
                     okay_files += o
                     failed_files += f


### PR DESCRIPTION
main calls with source_paths=None, but it needs to be iterable