### PR TITLE
Use LOAD_ARG in 3.6

### DIFF
--- a/uncompyle6/parsers/parse3.py
+++ b/uncompyle6/parsers/parse3.py
@@ -65,7 +65,9 @@ class Python3Parser(PythonParser):
 
         list_comp ::= BUILD_LIST_0 list_iter
         lc_body   ::= expr LIST_APPEND
-        list_for ::= expr FOR_ITER store list_iter jb_or_c
+        list_for  ::= expr_or_arg
+                      FOR_ITER
+                      store list_iter jb_or_c
 
         # This is seen in PyPy, but possibly it appears on other Python 3?
         list_if     ::= expr jmp_false list_iter COME_FROM
@@ -77,10 +79,10 @@ class Python3Parser(PythonParser):
 
         stmt ::= set_comp_func
 
-        set_comp_func ::= BUILD_SET_0 LOAD_FAST FOR_ITER store comp_iter
+        set_comp_func ::= BUILD_SET_0 LOAD_ARG FOR_ITER store comp_iter
                           JUMP_BACK RETURN_VALUE RETURN_LAST
 
-        set_comp_func ::= BUILD_SET_0 LOAD_FAST FOR_ITER store comp_iter
+        set_comp_func ::= BUILD_SET_0 LOAD_ARG FOR_ITER store comp_iter
                           COME_FROM JUMP_BACK RETURN_VALUE RETURN_LAST
 
         comp_body ::= dict_comp_body
@@ -88,6 +90,8 @@ class Python3Parser(PythonParser):
         dict_comp_body ::= expr expr MAP_ADD
         set_comp_body ::= expr SET_ADD
 
+        expr_or_arg     ::= LOAD_ARG
+        expr_or_arg     ::= expr
         # See also common Python p_list_comprehension
         """
 
@@ -95,7 +99,7 @@ class Python3Parser(PythonParser):
         """"
         expr ::= dict_comp
         stmt ::= dict_comp_func
-        dict_comp_func ::= BUILD_MAP_0 LOAD_FAST FOR_ITER store
+        dict_comp_func ::= BUILD_MAP_0 LOAD_ARG FOR_ITER store
                            comp_iter JUMP_BACK RETURN_VALUE RETURN_LAST
 
         comp_iter     ::= comp_if_not

--- a/uncompyle6/parsers/parse37base.py
+++ b/uncompyle6/parsers/parse37base.py
@@ -660,7 +660,7 @@ class Python37BaseParser(PythonParser):
                                             store func_async_middle list_iter
                                             JUMP_BACK COME_FROM
                                             POP_TOP POP_TOP POP_TOP POP_EXCEPT POP_TOP
-                    list_comp_async     ::= BUILD_LIST_0 LOAD_FAST list_afor2
+                    list_comp_async     ::= BUILD_LIST_0 LOAD_ARG list_afor2
                     get_aiter           ::= expr GET_AITER
                     list_afor           ::= get_aiter list_afor2
                     list_iter           ::= list_afor

--- a/uncompyle6/scanners/scanner3.py
+++ b/uncompyle6/scanners/scanner3.py
@@ -601,6 +601,10 @@ class Scanner3(Scanner):
                     # other parts like n_LOAD_CONST in pysource.py for example.
                     pattr = const
                     pass
+            elif opname == "LOAD_FAST" and argval == ".0":
+                # Used as the parameter of a list expression
+                opname = "LOAD_ARG"
+
             elif opname in ("MAKE_FUNCTION", "MAKE_CLOSURE"):
                 if self.version >= (3, 6):
                     # 3.6+ doesn't have MAKE_CLOSURE, so opname == 'MAKE_FUNCTION'

--- a/uncompyle6/semantics/customize36.py
+++ b/uncompyle6/semantics/customize36.py
@@ -693,6 +693,16 @@ def customize_for_version36(self, version):
 
     self.n_joined_str = n_joined_str
 
+    def n_list_comp_async(node):
+        self.write("[")
+        if node[0].kind == "load_closure":
+            self.listcomp_closure3(node)
+        else:
+            self.comprehension_walk_newer(node, iter_index=3, code_index=0)
+        self.write("]")
+        self.prune()
+    self.n_list_comp_async = n_list_comp_async
+
     # def kwargs_only_36(node):
     #     keys = node[-1].attr
     #     num_kwargs = len(keys)


### PR DESCRIPTION
Use LOAD_FAST -> LOAD_ARG when it is that  (as name `.0`). 

This makes grammar clearer. Also we add a few more async rules from the 3.7 grammar.