### PR TITLE
Add missing ParserError2 in make_functions36

### DIFF
--- a/uncompyle6/semantics/make_function36.py
+++ b/uncompyle6/semantics/make_function36.py
@@ -25,6 +25,7 @@ from xdis import (
 )
 from uncompyle6.scanner import Code
 from uncompyle6.semantics.parser_error import ParserError
+from uncompyle6.parser import ParserError as ParserError2
 from uncompyle6.semantics.helper import (
     find_all_globals,
     find_globals_and_nonlocals,


### PR DESCRIPTION
Should fix:
```python
uncompyle6/semantics/make_function36.py", line 170, in make_function36
    except (ParserError, ParserError2) as p:
NameError: name 'ParserError2' is not defined
```