### PR TITLE
ensure parser has opc attribute

### DIFF
--- a/uncompyle6/parsers/reducecheck/while1stmt.py
+++ b/uncompyle6/parsers/reducecheck/while1stmt.py
@@ -42,7 +42,7 @@ def while1stmt(self, lhs, n, rule, ast, tokens, first, last):
         # token could be a pseudo-op like "LOAD_STR", which is not in
         # self.opc.  We will replace that with LOAD_CONST as an
         # example of an instruction that is not in self.opc.JUMP_OPS
-        if self.opc.opmap.get(token.kind, "LOAD_CONST") in self.opc.JUMP_OPS:
+        if hasattr(self, 'opc') and self.opc.opmap.get(token.kind, "LOAD_CONST") in self.opc.JUMP_OPS:
             if token.attr >= loop_end_offset:
                 return True
 


### PR DESCRIPTION
Note sure if this is correct fix but seems to fix:
```python
uncompyle6/parsers/reducecheck/while1stmt.py", line 45, in while1stmt
    if self.opc.opmap.get(token.kind, "LOAD_CONST") in self.opc.JUMP_OPS:
AttributeError: 'Python36Parser' object has no attribute 'opc'
```