### PR TITLE
Fix status_msg args

### DIFF
--- a/uncompyle6/bin/uncompile.py
+++ b/uncompyle6/bin/uncompile.py
@@ -196,9 +196,9 @@ def main_bin():
         try:
             result = main(src_base, out_base, pyc_paths, source_paths, outfile,
                           **options)
-            result = list(result) + [options.get('do_verify', None)]
+            result = [options.get('do_verify', None)] + list(result)
             if len(pyc_paths) > 1:
-                mess = status_msg(do_verify, *result)
+                mess = status_msg(*result)
                 print('# ' + mess)
                 pass
         except ImportError as e:


### PR DESCRIPTION
Fixes:
```python
uncompyle6/bin/uncompile.py", line 201, in main_bin
    mess = status_msg(do_verify, *result)
TypeError: status_msg() takes 5 positional arguments but 6 were given
```