### PR TITLE
Tentative fix for issue #437.

### DIFF
--- a/uncompyle6/parsers/reducecheck/ifelsestmt.py
+++ b/uncompyle6/parsers/reducecheck/ifelsestmt.py
@@ -82,6 +82,16 @@ IFELSE_STMT_RULES = frozenset(
             ),
         ),
         (
+            'ifelsestmtc',
+            (
+                'testexpr',
+                'c_stmts_opt',
+                'JUMP_FORWARD',
+                'else_suite',
+                'come_froms'
+            ),
+        ),
+        (
             "ifelsestmt",
             (
                 "testexpr",


### PR DESCRIPTION
I followed your guidelines, and reworked ifelsestmt.py a bit. I just added another set of rules that is then checked for offsets, it fixed this particular issue (#437) at least. I know the tests in test/ aren't great, but at least they aren't failing :)

I ran the tests on test/stdlib/runtests.sh also (Python 2.7) but I keep getting an error, which I included in issue #439. I might look into that one also since I am working on it.



