### PR TITLE
Tentative fix for issue #439

### DIFF
--- a/uncompyle6/scanners/scanner2.py
+++ b/uncompyle6/scanners/scanner2.py
@@ -360,7 +360,7 @@ class Scanner2(Scanner):
                         pattr = const
                         pass
                 elif op in self.opc.NAME_OPS:
-                    pattr = names[oparg]
+                    pattr = PattrWrapper(names[oparg])
                 elif op in self.opc.JREL_OPS:
                     #  use instead: hasattr(self, 'patch_continue'): ?
                     if self.version[:2] == (2, 7):
@@ -1452,3 +1452,43 @@ class Scanner2(Scanner):
             instr_offsets = filtered
             filtered = []
         return instr_offsets
+
+
+class PattrWrapper(object):
+    def __init__(self,str1):
+        self.str1 = str1
+
+    def __repr__(self):
+        return self.str1
+
+    def __getattr__(self,name):
+        return getattr(self.str1,name)
+
+    def __str__(self):
+        return self.str1
+
+    def do_cmp(self,targ,fn):
+        if (isinstance(targ,PattrWrapper)):
+            targ = targ.str1
+        return fn(targ)
+
+    def __lt__(self, other):
+        return self.do_cmp(other,self.str1.__lt__)
+
+    def __le__(self, other):
+        return self.do_cmp(other,self.str1.__le__)
+
+    def __eq__(self, other):
+        return self.do_cmp(other,self.str1.__eq__)
+
+    def __ne__(self, other):
+        return self.do_cmp(other,self.str1.__ne__)
+
+    def __gt__(self, other):
+        return self.do_cmp(other,self.str1.__gt__)
+
+    def __ge__(self, other):
+        return self.do_cmp(other,self.str1.__ge__)
+
+    def __hash__(self):
+        return self.str1.__hash__()

--- a/uncompyle6/semantics/customize26_27.py
+++ b/uncompyle6/semantics/customize26_27.py
@@ -63,6 +63,6 @@ def customize_for_version26_27(self, version):
 
     def n_import_from(node):
         if node[0].pattr > 0:
-            node[2].pattr = ("." * node[0].pattr) + node[2].pattr
+            node[2].pattr = ("." * node[0].pattr) + str(node[2].pattr)
         self.default(node)
     self.n_import_from = n_import_from

--- a/uncompyle6/semantics/n_actions.py
+++ b/uncompyle6/semantics/n_actions.py
@@ -67,7 +67,7 @@ class NonterminalActions:
         assert store_node.kind.startswith("STORE_")
         iname = node[0].pattr  # import name
         sname = store_node.pattr  # store_name
-        if iname and iname == sname or iname.startswith(sname + "."):
+        if iname and iname == sname or iname.startswith(str(sname) + "."):
             self.write(iname)
         else:
             self.write(iname, " as ", sname)


### PR DESCRIPTION
What I did was add a wrapper to pattr in scanner2.py, when transforming the disasm into the intermediate abstraction. It is a class, that essentially gives a specific __repr__ without the quotes when the translator emits the source code later. I added a few str() around to make sure the behavior is consistent overall.

Tests in test/ worked, still struggling with test/stdlib ones, but I am trying to fix all the unicode stuff.