### PR TITLE
Proposed fix for the extra quotes

### DIFF
--- a/uncompyle6/semantics/n_actions.py
+++ b/uncompyle6/semantics/n_actions.py
@@ -267,7 +267,10 @@ class NonterminalActions:
                 if elem == "add_value":
                     elem = elem[0]
                 if elem == "ADD_VALUE":
-                    value = "%r" % elem.pattr
+                    if self.version[0] == 2:
+                        value = "%r" % elem.pattr
+                    else:
+                        value = "%s" % elem.pattr
                 else:
                     assert elem.kind == "ADD_VALUE_VAR"
                     value = "%s" % elem.pattr


### PR DESCRIPTION
I separated repr and str by Python version. The test is still broken, the 3.8 bytecode is being decompiled in wrong blocks, I might look into that later.