### PR TITLE
Support high version python to decompile low version pyc

### DIFF
--- a/uncompyle6/__init__.py
+++ b/uncompyle6/__init__.py
@@ -46,6 +46,9 @@ from uncompyle6.main import decompile_file  # noqa
 
 from uncompyle6.semantics.pysource import code_deparse, deparse_code2str
 
+
+PYC_version = 3.6
+
 __all__ = [
     "__version__",
     "code_deparse",

--- a/uncompyle6/bin/uncompile.py
+++ b/uncompyle6/bin/uncompile.py
@@ -62,7 +62,7 @@ Extensions of generated files:
 
 program = 'uncompyle6'
 
-from uncompyle6 import verify
+from uncompyle6 import verify, PYC_version
 from uncompyle6.main import main, status_msg
 from uncompyle6.version import __version__
 
@@ -72,7 +72,8 @@ def usage():
 
 
 def main_bin():
-    if not (sys.version_info[0:2] in ((2, 6), (2, 7), (3, 0),
+    ver = (int(PYC_version), int((PYC_version - int(PYC_version)) * 10))
+    if not (ver in ((2, 6), (2, 7), (3, 0),
                                       (3, 1), (3, 2), (3, 3),
                                       (3, 4), (3, 5), (3, 6),
                                       (3, 7), (3, 8), (3, 9), (3, 10)

--- a/uncompyle6/main.py
+++ b/uncompyle6/main.py
@@ -32,6 +32,8 @@ from uncompyle6.semantics.linemap import deparse_code_with_map
 
 from xdis.load import load_module
 
+from uncompyle6 import PYC_version
+
 def _get_outstream(outfile: str) -> Any:
     dir = os.path.dirname(outfile)
     failed_file = outfile + "_failed"
@@ -191,6 +193,8 @@ def decompile_file(
     (version, timestamp, magic_int, co, is_pypy, source_size, sip_hash) = load_module(
         filename, code_objects
     )
+
+    PYC_version = version
 
     if isinstance(co, list):
         deparsed = []

--- a/uncompyle6/scanners/tok.py
+++ b/uncompyle6/scanners/tok.py
@@ -83,22 +83,27 @@ class Token:
             self.pattr = None
 
         if opc is None:
-            try:
-                from xdis.std import _std_api
-            except KeyError as e:
-                print(f"I don't know about Python version {e} yet.")
-                try:
-                    version_tuple = tuple(int(i) for i in str(e)[1:-1].split("."))
-                except Exception:
-                    pass
-                else:
-                    if version_tuple > (3, 9):
-                        print("Python versions 3.9 and greater are not supported.")
-                    else:
-                        print(f"xdis might need to be informed about version {e}")
-                return
+            from uncompyle6 import PYC_version
+            from xdis.std import make_std_api
 
-            self.opc = _std_api.opc
+            self.opc = make_std_api(PYC_version).opc
+
+            # try:
+            #     from xdis.std import _std_api
+            # except KeyError as e:
+            #     print(f"I don't know about Python version {e} yet.")
+            #     try:
+            #         version_tuple = tuple(int(i) for i in str(e)[1:-1].split("."))
+            #     except Exception:
+            #         pass
+            #     else:
+            #         if version_tuple > (3, 9):
+            #             print("Python versions 3.9 and greater are not supported.")
+            #         else:
+            #             print(f"xdis might need to be informed about version {e}")
+            #     return
+
+            # self.opc = _std_api.opc
         else:
             self.opc = opc
         if op is None:


### PR DESCRIPTION
Uncompyle6 uses the current Python interpreter version as the default .pyc version, which prevents Python 3.11 from working, even if the .pyc version is 3.8 or lower. I made some small modifications to specify the version of .pyc when generating tokens, which may be helpful. Due to time constraints, I only tested a few pyc file. Sorry for that. :(
Also, it maybe need to change `xdis/std.py`:
```python
from uncompyle6 import PYC_version
_std_api = make_std_api(PYC_version)
```