### PR TITLE
Deterministic set order in LOAD_CONST

### DIFF
--- a/uncompyle6/semantics/n_actions.py
+++ b/uncompyle6/semantics/n_actions.py
@@ -1241,6 +1241,13 @@ class NonterminalActions:
             self.write("None")
         elif isinstance(data, tuple):
             self.pp_tuple(data)
+        elif isinstance(data, set):
+            # Deterministic set order.
+            self.write("{")
+            map_str_repr_to_data = {repr(x): x for x in data}
+            order = [map_str_repr_to_data[x] for x in sorted(map_str_repr_to_data)]
+            self.write(", ".join(repr(x) for x in order))
+            self.write("}")
         elif isinstance(attr, bool):
             self.write(repr(attr))
         elif self.FUTURE_UNICODE_LITERALS:


### PR DESCRIPTION
This PR attempts to fix the decompilation of simple sets defined as `LOAD_CONST`. Sets were decompiled correctly but the order of elements was not defined.

# Test input
This was my test input compiled by the Python 3.6:
```python
if v in {'element', 5, 'attlist', 'linktype', 'link'}:
	print(v)
```

# Disassembly
```

 L.   1         0  LOAD_NAME                v
                2  LOAD_CONST               {'attlist', 5, 'linktype', 'link', 'element'}
                4  COMPARE_OP               in
                6  POP_JUMP_IF_FALSE    16  'to 16'

 L.   2         8  LOAD_NAME                print
               10  LOAD_NAME                v
               12  CALL_FUNCTION         1  '1 positional argument'
               14  POP_TOP          
             16_0  COME_FROM             6  '6'
               16  LOAD_CONST               None
               18  RETURN_VALUE  
```

# Decompilation outputs before patch
### Attempt n. 1:
```python
if v in {5, 'attlist', 'linktype', 'link', 'element'}:
    print(v)
```

### Attempt n. 2:
```python
if v in {'element', 5, 'linktype', 'link', 'attlist'}:
    print(v)
```


# Decompilation output after patch
```python
if v in {'attlist', 'element', 'link', 'linktype', 5}:
    print(v)
```