### PR TITLE
Use a single TABLE copy

### DIFF
--- a/uncompyle6/semantics/customize.py
+++ b/uncompyle6/semantics/customize.py
@@ -29,7 +29,6 @@ from uncompyle6.semantics.helper import flatten_list
 
 
 def customize_for_version(self, is_pypy, version):
-    self.TABLE_DIRECT = TABLE_DIRECT.copy()
     if is_pypy:
         ########################
         # PyPy changes
@@ -264,7 +263,6 @@ def customize_for_version(self, is_pypy, version):
 
         # < 3.0 continues
 
-        self.TABLE_R = TABLE_R.copy()
         self.TABLE_R.update(
             {
                 "STORE_SLICE+0": ("%c[:]", 0),

--- a/uncompyle6/semantics/customize25.py
+++ b/uncompyle6/semantics/customize25.py
@@ -25,7 +25,7 @@ def customize_for_version25(self, version):
     ########################
     # Import style for 2.5+
     ########################
-    TABLE_DIRECT.update(
+    self.TABLE_DIRECT.update(
         {
             "importmultiple": ("%|import %c%c\n", 2, 3),
             "import_cont": (", %c", 2),

--- a/uncompyle6/semantics/customize26_27.py
+++ b/uncompyle6/semantics/customize26_27.py
@@ -19,7 +19,6 @@ from uncompyle6.semantics.consts import TABLE_DIRECT
 
 
 def customize_for_version26_27(self, version: tuple):
-    self.TABLE_DIRECT = TABLE_DIRECT.copy()
     ########################################
     # Python 2.6+
     #    except <condition> as <var>

--- a/uncompyle6/semantics/customize3.py
+++ b/uncompyle6/semantics/customize3.py
@@ -30,7 +30,6 @@ from uncompyle6.util import get_code_name
 
 
 def customize_for_version3(self, version: tuple):
-    self.TABLE_DIRECT = TABLE_DIRECT.copy()
     self.TABLE_DIRECT.update(
         {
             "comp_for": (" for %c in %c", (2, "store"), (0, "expr")),

--- a/uncompyle6/semantics/customize35.py
+++ b/uncompyle6/semantics/customize35.py
@@ -26,7 +26,6 @@ from uncompyle6.semantics.helper import flatten_list, gen_function_parens_adjust
 #######################
 def customize_for_version35(self, version: tuple):
     # fmt: off
-    self.TABLE_DIRECT = TABLE_DIRECT.copy()
     self.TABLE_DIRECT.update(
         {
             # nested await expressions like:

--- a/uncompyle6/semantics/customize36.py
+++ b/uncompyle6/semantics/customize36.py
@@ -96,7 +96,6 @@ def customize_for_version36(self, version: tuple):
         }
     )
 
-    self.TABLE_R = TABLE_R.copy()
     self.TABLE_R.update(
         {
             "CALL_FUNCTION_EX":    ("%c(*%P)", 0, (1, 2, ", ", 100)),

--- a/uncompyle6/semantics/customize37.py
+++ b/uncompyle6/semantics/customize37.py
@@ -30,8 +30,6 @@ def customize_for_version37(self, version: tuple):
     # Python 3.7+ changes
     #######################
 
-    self.TABLE_DIRECT = TABLE_DIRECT.copy()
-
     # fmt: off
     PRECEDENCE["attribute37"]      =   2
     PRECEDENCE["call_ex"]          =   1

--- a/uncompyle6/semantics/customize38.py
+++ b/uncompyle6/semantics/customize38.py
@@ -29,8 +29,6 @@ def customize_for_version38(self, version: tuple):
     # for lhs in 'for forelsestmt forelselaststmt '
     #             'forelselaststmtc tryfinally38'.split():
     #     del TABLE_DIRECT[lhs]
-
-    self.TABLE_DIRECT = TABLE_DIRECT.copy()
     self.TABLE_DIRECT.update(
         {
             "async_for_stmt38": (

--- a/uncompyle6/semantics/fragments.py
+++ b/uncompyle6/semantics/fragments.py
@@ -656,8 +656,6 @@ class FragmentsWalker(pysource.SourceWalker, object):
         code = Code(cn.attr, self.scanner, self.currentclass)
         ast = self.build_ast(code._tokens, code._customize, code)
 
-        self.TABLE_DIRECT = TABLE_DIRECT.copy()
-        self.TABLE_R = TABLE_R.copy()
         self.MAP_DIRECT = (self.TABLE_DIRECT,)
         self.MAP_R = (self.TABLE_R, -1)
 


### PR DESCRIPTION
Do not overwrite possible previous updates to the new TABLE_R and TABLE_DIRECT dictionaries.