### PR TITLE
Change copyright year to 2018

### DIFF
--- a/uncompyle6/linenumbers.py
+++ b/uncompyle6/linenumbers.py
@@ -1,4 +1,4 @@
-#  Copyright (c) 2015-2016, 2818, 2020 by Rocky Bernstein
+#  Copyright (c) 2015-2016, 2018, 2020 by Rocky Bernstein
 #
 #  This program is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
The copyright date listed in `linenumpers.py` includes the year 2818; this changes it to 2018.